### PR TITLE
chore: 공통 응답 DTO 생성

### DIFF
--- a/backend/src/main/java/com/swu/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/swu/global/response/ApiResponse.java
@@ -1,0 +1,32 @@
+package com.swu.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiResponse<T> {
+
+    private int status;      // HTTP 상태 코드 (200, 400, 500 등)
+    private String message;  // 응답 메시지
+    private T data;          // 응답 데이터
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(HttpStatus.OK.value(), "성공", data);
+    }
+
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return new ApiResponse<>(HttpStatus.OK.value(), message, data);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(HttpStatus.BAD_REQUEST.value(), message, null);
+    }
+
+    public static <T> ApiResponse<T> error(HttpStatus status, String message) {
+        return new ApiResponse<>(status.value(), message, null);
+    }
+}


### PR DESCRIPTION
## 요약
- 모든 API 응답을 일관된 포맷(`status`, `message`, `data`)으로 감싸기 위한 공통 DTO `ApiResponse<T>` 생성

<br><br>

## 작업 내용
- `com.swu.global.response.ApiResponse<T>` 클래스 추가
- 정적 팩토리 메서드:
  - `ok(data)`
  - `ok(message, data)`
  - `error(status, message)`
  - `error(message)`
<br><br>

## 참고 사항
- 사용예시
```java
return ResponseEntity.ok(ApiResponse.ok("회원가입 성공", userDto));
```
<br><br>

## 관련 이슈

- Close #7 

<br><br>
