### PR TITLE
feat: JWT 로그인 필터 및 인증 처리 로직 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -56,6 +56,12 @@ dependencies {
 
 	// Validation API
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/swu/auth/domain/CustomUserDetails.java
+++ b/backend/src/main/java/com/swu/auth/domain/CustomUserDetails.java
@@ -1,0 +1,60 @@
+package com.swu.auth.domain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.swu.user.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import lombok.Getter;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    // 사용자가 가진 권한 목록 반환
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(() -> "ROLE_" + user.getRole());
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/backend/src/main/java/com/swu/auth/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/swu/auth/dto/request/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.swu.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
@@ -1,0 +1,109 @@
+package com.swu.auth.jwt;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swu.auth.domain.CustomUserDetails;
+import com.swu.global.response.ApiResponse;
+import com.swu.user.domain.Role;
+import com.swu.user.domain.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Slf4j
+public class JWTFilter extends OncePerRequestFilter{
+
+    private final JWTUtil jwtUtil;
+
+    public JWTFilter(JWTUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        if (path.startsWith("/auth")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization == null || !authorization.startsWith("Bearer")) {
+
+            log.warn("토큰이 없거나 Bearer로 시작하지 않음");
+            sendUnauthorizedResponse(response, "토큰이 없거나 형식이 올바르지 않습니다.");
+
+            return;
+        }
+
+        log.debug("Authorization header found");
+
+        // Bearer 부분 제거 후 순수 토큰 획득
+        String token = authorization.split(" ")[1];
+
+        // 토큰 소멸 시간 검증
+        if (jwtUtil.isExpired(token)) {
+
+            log.warn("토큰 만료됨");
+            sendUnauthorizedResponse(response, "토큰이 만료되었습니다.");
+
+            return;
+        }
+
+        String username = jwtUtil.getUsername(token);
+        String role = jwtUtil.getRole(token);
+        Integer id = jwtUtil.getId(token);
+
+        log.info("토큰 추출 - email: {}, role: {}, id: {}", username, role, id);
+
+        Role roleType;
+        roleType = Role.valueOf(role);
+
+        //userEntity를 생성하여 값 set
+        User user = User.builder()
+                .id((long) id)
+                .email(username)
+                .password("temppassword")
+                .role(roleType)
+                .build();
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+        log.info("User added to SecurityContextHolder");
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendUnauthorizedResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<Void> apiResponse = ApiResponse.unauthorized(message);  // ApiResponse에 해당 메서드가 있다고 가정
+        ObjectMapper objectMapper = new ObjectMapper();
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+
+        response.getWriter().write(responseBody);
+    }
+
+
+}

--- a/backend/src/main/java/com/swu/auth/jwt/JWTUtil.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTUtil.java
@@ -1,0 +1,72 @@
+package com.swu.auth.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+
+@Component
+public class JWTUtil {
+
+    private final SecretKey secretKey;
+
+    public JWTUtil(@Value("${jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("username", String.class);
+    }
+
+    public Integer getId(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("id", Integer.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration()
+                .before(new Date());
+    }
+
+    public String createJwt (String username, String role, Long Id, Long expiredMs) {
+        Date now = new Date();
+        Date expirationDate = new Date(now.getTime() + expiredMs);
+        return Jwts.builder()
+                .claim("username", username)
+                .claim("id", Id)
+                .claim("role", role.replace("ROLE_", ""))
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expirationDate)
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
@@ -1,0 +1,118 @@
+package com.swu.auth.jwt;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.swu.auth.domain.CustomUserDetails;
+import com.swu.auth.dto.request.LoginRequest;
+import com.swu.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StreamUtils;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+// JWT 사용한 인증 방식을 구현을 위해 커스텀 필터 작성.
+// UsernamePasswordAuthenticationFilter -> 로그인 가로챔
+@Slf4j
+public class LoginFilter extends UsernamePasswordAuthenticationFilter{
+
+    // 인증 요청 처리, 사용자 인증 정보 검증하는 역할.
+    // 커스텀 필터에서 사용하기 위해 주입받음
+    private final  AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+
+    public LoginFilter (AuthenticationManager authenticationManager, JWTUtil jwtUtil) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+
+        setFilterProcessesUrl("/auth/login");
+    }
+
+    // 로그인 요청을 처리하는 메소드
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException  {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ServletInputStream inputStream = request.getInputStream();
+            String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            LoginRequest loginRequest = objectMapper.readValue(messageBody, LoginRequest.class);
+
+            String username = loginRequest.getEmail();
+            String password = loginRequest.getPassword();
+
+            // 인증 토큰 생성
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+
+            // 인증 시도
+            return authenticationManager.authenticate(authToken);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //로그인 성공시 실행하는 메소드
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        String username = customUserDetails.getUsername();
+        Long  id = customUserDetails.getUser().getId();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String role = auth.getAuthority();
+
+        String token = jwtUtil.createJwt(username, role, id, 10 * 60 * 60 * 1000L); // 10시간 설정
+
+        // 헤더에 토큰 설정
+        response.setHeader("Authorization", "Bearer " + token);
+
+        // 바디 구성
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("id", id);
+        data.put("email", username);
+
+        ApiResponse<Map<String, Object>> apiResponse = ApiResponse.ok("로그인 성공", data);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try{
+            String responseBody = objectMapper.writeValueAsString(apiResponse);
+            response.getWriter().write(responseBody);
+        } catch (IOException e) {
+            log.error("JSON 직렬화 중 오류 발생", e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+
+
+        log.info("User {} login success", username);
+    }
+
+    //로그인 실패시 실행하는 메소드
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        response.setStatus(401);
+
+        log.info("User login failed");
+    }
+}

--- a/backend/src/main/java/com/swu/auth/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/swu/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.swu.auth.service;
+
+import com.swu.auth.domain.CustomUserDetails;
+import com.swu.user.domain.User;
+import com.swu.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/backend/src/main/java/com/swu/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/swu/global/config/SecurityConfig.java
@@ -1,14 +1,28 @@
 package com.swu.global.config;
 
+import com.swu.auth.jwt.JWTFilter;
+import com.swu.auth.jwt.JWTUtil;
+import com.swu.auth.jwt.LoginFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JWTUtil jwtUtil;
+
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil) {
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtUtil = jwtUtil;
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -17,12 +31,28 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> csrf.disable());
+
+        http
+                .formLogin(form -> form.disable());
+
+        http
+                .httpBasic(httpBasic -> httpBasic.disable());
+
+        http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 );
+
+        http
+                .addFilterAt(new LoginFilter(authenticationConfiguration.getAuthenticationManager(), jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(new JWTFilter(jwtUtil), LoginFilter.class);
+
+        http
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }

--- a/backend/src/main/java/com/swu/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/swu/global/response/ApiResponse.java
@@ -29,4 +29,9 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> error(HttpStatus status, String message) {
         return new ApiResponse<>(status.value(), message, null);
     }
+
+    public static <T> ApiResponse<T> unauthorized(String message) {
+        return new ApiResponse<>(401, message, null);
+    }
+
 }

--- a/backend/src/main/java/com/swu/user/domain/User.java
+++ b/backend/src/main/java/com/swu/user/domain/User.java
@@ -10,7 +10,7 @@ import java.sql.Timestamp;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class User {
 
     @Id

--- a/backend/src/main/java/com/swu/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/swu/user/repository/UserRepository.java
@@ -3,6 +3,9 @@ package com.swu.user.repository;
 import com.swu.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
## 요약
JWT를 활용한 로그인 인증 기능을 구현.  
로그인 성공 시 Access Token이 헤더에 포함되어 응답.
<br><br>

## 작업 내용
- `LoginFilter` 커스텀 구현: 로그인 요청 가로채기 및 인증 시도
- `JWTUtil` 구현: 토큰 생성, 검증, Claim 추출
- `JWTFilter` 구현: 모든 요청에 대해 JWT 기반 인증 처리
- `CustomUserDetails`, `CustomUserDetailsService` 추가
- `ApiResponse`에 `unauthorized()` 응답 포맷 추가
- `/auth/**` 경로에 인증 제외 설정
- `UserRepository`에 `findByEmail()` 추가
- `User` 엔티티에 기본 생성자 접근자 수정
```
{
    "status": 200,
    "message": "로그인 성공",
    "data": {
        "id": 2,
        "email": "aa@naver.com"
    }
}
{
    "status": 401,
    "message": "토큰이 없거나 형식이 올바르지 않습니다.",
    "data": null
}
```
<br><br>

## 참고 사항
- 현재는 Access Token만 발급하고 있으며, Refresh Token은 미포함
- 로그인 성공 시 토큰은 헤더(`Authorization`)에 포함
- 예외 상황(토큰 없음/만료 등) 시 공통 포맷으로 JSON 응답 전송

<br><br>

## 관련 이슈

- Close #5 

<br><br>
