### PR TITLE
feat: 실시간 채팅방 기능 초기 구현 (WebSocket + STOMP) 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,6 +62,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	//  Websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
@@ -34,7 +34,7 @@ public class JWTFilter extends OncePerRequestFilter{
             throws ServletException, IOException {
         String path = request.getRequestURI();
 
-        if (path.startsWith("/auth")) {
+        if (path.startsWith("/auth") || path.startsWith("/ws")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/backend/src/main/java/com/swu/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/swu/chat/controller/ChatController.java
@@ -1,0 +1,24 @@
+package com.swu.chat.controller;
+
+import com.swu.chat.dto.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat/message")
+    public void handleChatMessage(ChatMessage message) {
+        log.info("메시지: {}", message);
+
+        Long roomId = message.getRoomId();
+        messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, message);
+    }
+}

--- a/backend/src/main/java/com/swu/chat/dto/ChatMessage.java
+++ b/backend/src/main/java/com/swu/chat/dto/ChatMessage.java
@@ -1,0 +1,32 @@
+package com.swu.chat.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatMessage {
+
+    public enum MessageType {
+        ENTER, // 입장
+        TALK,  // 채팅
+        EXIT   // 퇴장
+    }
+
+    private MessageType type;
+    private Long roomId;
+    private Long senderId;
+    private String senderNickname;
+    private String message;
+
+    @Override
+    public String toString() {
+        return "ChatMessage{" +
+                "type=" + type +
+                ", roomId=" + roomId +
+                ", senderId=" + senderId +
+                ", senderNickname='" + senderNickname + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}

--- a/backend/src/main/java/com/swu/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/swu/global/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/auth/**", "/ws/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/backend/src/main/java/com/swu/global/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/swu/global/config/WebMvcConfig.java
@@ -1,0 +1,18 @@
+package com.swu.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*") // 개발 중이니까 모든 origin 허용
+                .allowedMethods("*")        // GET, POST 등 전부 허용
+                .allowedHeaders("*")
+                .allowCredentials(true);    // 쿠키 허용 (선택사항)
+    }
+}

--- a/backend/src/main/java/com/swu/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/swu/global/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.swu.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.*;
+
+@Configuration // 스프링 설정 클래스
+@EnableWebSocketMessageBroker // 웹소켓 + STOMP 활성화
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // 클라이언트가 구독할 수 있는 prefix
+        config.enableSimpleBroker("/sub");
+
+        // 클라이언트에서 메시지 보낼 때 prefix
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat").setAllowedOriginPatterns("*").withSockJS();
+    }
+}


### PR DESCRIPTION
## 요약
STOMP 기반 WebSocket을 이용한 단체 채팅 기능의 백엔드 구조를 구현
기본적인 메시지 전송/구독이 가능하며, ChatMessage DTO 및 Controller를 구성
<br><br>

## 작업 내용
- `WebSocketConfig` 설정 추가 (`/ws/chat` 엔드포인트, `/sub`, `/app` prefix 지정)
- `ChatMessage` DTO 생성
- `ChatController` 생성 및 `@MessageMapping("/chat/message")` 처리
- `JWTFilter`에 `/ws/**` 허용 경로 추가
- `SecurityConfig`에 WebSocket 경로 허용 설정 추가
- `WebMvcConfig`를 통한 CORS 허용 설정 추가
- 기본 테스트 HTML을 통해 WebSocket 메시지 송수신 확인 완료
<br><br>

## 참고 사항
- 현재는 메시지 persistence(저장) 기능은 없으며, 브로드캐스트만 가능
- 추후 사용자 인증 연동 및 메시지 저장, 입/퇴장 로직 개선 필요

<br><br>

## 관련 이슈

- Close #19 

<br><br>
