### PR TITLE
feat: Room 생성 및 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/swu/room/controller/RoomController.java
+++ b/backend/src/main/java/com/swu/room/controller/RoomController.java
@@ -1,0 +1,45 @@
+package com.swu.room.controller;
+
+import com.swu.global.response.ApiResponse;
+import com.swu.room.dto.request.RoomRequest;
+import com.swu.room.dto.response.RoomResponse;
+import com.swu.room.service.RoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RestController
+@RequestMapping("/room")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @Operation(summary = "스터디 방 생성", description = "방을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<RoomResponse>> createRoom(@RequestBody RoomRequest request) {
+        roomService.createRoom(request);
+        return ResponseEntity.ok(ApiResponse.ok("방 생성 성공", null));
+    }
+
+    @Operation(summary = "전체 방 목록 조회", description = "현재 존재하는 모든 스터디 방 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RoomResponse>>> getAllRooms() {
+        List<RoomResponse> rooms = roomService.getAllRooms();
+        return ResponseEntity.ok(ApiResponse.ok("방 목록 조회 성공", rooms));
+    }
+
+
+    @Operation(summary = "단일 방 조회", description = "roomId로 특정 방 정보를 조회합니다.")
+    @GetMapping("/{roomId}")
+    public ResponseEntity<ApiResponse<RoomResponse>> getRoom(@PathVariable Long roomId) {
+        RoomResponse room = roomService.getRoom(roomId);
+        return ResponseEntity.ok(ApiResponse.ok("방 조회 성공", room));
+    }
+
+}

--- a/backend/src/main/java/com/swu/room/domain/Bgm.java
+++ b/backend/src/main/java/com/swu/room/domain/Bgm.java
@@ -1,9 +1,11 @@
 package com.swu.room.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.hibernate.annotations.Immutable;
 
 @Entity
+@Getter
 @Immutable
 public class Bgm {
 
@@ -16,4 +18,5 @@ public class Bgm {
 
     @Column(nullable = false, length = 255)
     private String audioUrl;
+
 }

--- a/backend/src/main/java/com/swu/room/domain/Room.java
+++ b/backend/src/main/java/com/swu/room/domain/Room.java
@@ -5,6 +5,8 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -31,6 +33,9 @@ public class Room {
 
     @Column(nullable = false)
     private int breakMinute;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoomMember> members = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bgm_id")

--- a/backend/src/main/java/com/swu/room/domain/Room.java
+++ b/backend/src/main/java/com/swu/room/domain/Room.java
@@ -40,4 +40,9 @@ public class Room {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bgm_id")
     private Bgm bgm;
+
+    public void addMember(RoomMember member) {
+        members.add(member);
+        member.setRoom(this);
+    }
 }

--- a/backend/src/main/java/com/swu/room/domain/RoomMember.java
+++ b/backend/src/main/java/com/swu/room/domain/RoomMember.java
@@ -33,4 +33,8 @@ public class RoomMember {
     private LocalDateTime exitedAt;
 
     private boolean isHost;
+
+    void setRoom(Room room) {
+        this.room = room;
+    }
 }

--- a/backend/src/main/java/com/swu/room/dto/request/RoomRequest.java
+++ b/backend/src/main/java/com/swu/room/dto/request/RoomRequest.java
@@ -1,0 +1,3 @@
+package com.swu.room.dto.request;
+
+public record RoomRequest(String title, int maxCapacity, int focusMinute, int breakMinute) {}

--- a/backend/src/main/java/com/swu/room/dto/response/RoomResponse.java
+++ b/backend/src/main/java/com/swu/room/dto/response/RoomResponse.java
@@ -1,0 +1,5 @@
+package com.swu.room.dto.response;
+
+import java.time.LocalDateTime;
+
+public record RoomResponse(Long id, String title, int maxCapacity, int focusMinute, int breakMinute, int currentMemberCount, LocalDateTime createdAt, String bgnTitle) {}

--- a/backend/src/main/java/com/swu/room/exception/RoomNotFoundException.java
+++ b/backend/src/main/java/com/swu/room/exception/RoomNotFoundException.java
@@ -1,0 +1,7 @@
+package com.swu.room.exception;
+
+public class RoomNotFoundException extends RuntimeException {
+    public RoomNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/swu/room/service/RoomService.java
+++ b/backend/src/main/java/com/swu/room/service/RoomService.java
@@ -1,0 +1,60 @@
+package com.swu.room.service;
+
+import com.swu.room.domain.Room;
+import com.swu.room.dto.request.RoomRequest;
+import com.swu.room.dto.response.RoomResponse;
+import com.swu.room.exception.RoomNotFoundException;
+import com.swu.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+
+    @Transactional
+    public void createRoom(RoomRequest request) {
+        Room room = Room.builder()
+                .title(request.title())
+                .maxCapacity(request.maxCapacity())
+                .focusMinute(request.focusMinute())
+                .breakMinute(request.breakMinute())
+                .build();
+
+        roomRepository.save(room);
+    }
+
+    @Transactional
+    public List<RoomResponse> getAllRooms() {
+        return roomRepository.findAll().stream()
+                .map(this::toRoomResponse)
+                .toList();
+    }
+
+    @Transactional
+    public RoomResponse getRoom(Long roomId) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new RoomNotFoundException("해당 방이 존재하지 않습니다."));
+        return toRoomResponse(room);
+    }
+
+    private RoomResponse toRoomResponse(Room room) {
+        return new RoomResponse(
+                room.getId(),
+                room.getTitle(),
+                room.getMaxCapacity(),
+                room.getFocusMinute(),
+                room.getBreakMinute(),
+                room.getMembers().size(),
+                room.getCreatedAt(),
+                room.getBgm() != null ? room.getBgm().getTitle() : null
+        );
+    }
+}
+


### PR DESCRIPTION
## 요약
Room 생성 및 조회 기능을 구현하였고, 요청/응답 DTO와 예외 처리, Bgm getter 추가

<br><br>

## 작업 내용
- `POST /room` 방 생성 API 구현
- `GET /room`, `GET /room/{id}` 전체/단건 조회 API 구현
- `RoomRequest`, `RoomResponse` DTO 생성
- `RoomNotFoundException` 추가 및 예외 처리
- `Bgm` 엔티티에 getter 메서드 추가
<br><br>

## 참고 사항
- 단건 조회 실패 시 전역 예외 핸들러 적용은 추후 작업 예정
- 방 참여 및 RoomMember 관련 로직은 별도 이슈에서 구현 예정

<br><br>

## 관련 이슈

- Close #22 

<br><br>
