### PR TITLE
feat: 전역 예외 처리 구현

### DIFF
--- a/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.swu.global.exception;
+
+import com.swu.global.response.ApiResponse;
+import com.swu.room.exception.RoomNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RoomNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRoomNotFoundException(RoomNotFoundException e) {
+        log.warn("RoomNotFoundException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(HttpStatus.NOT_FOUND, e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(Exception e) {
+        log.error("Unexpected error occurred", e); //
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."));
+    }
+}


### PR DESCRIPTION
## 요약
전역 예외 처리를 위한 GlobalExceptionHandler 를 구현 
예상 가능한 도메인 예외와 예상하지 못한 시스템 예외를 분리하여 처리하며,  
ApiResponse 형태로 통일된 에러 응답을 제공
<br><br>

## 작업 내용
- @RestControllerAdvice 기반 전역 예외 처리기 생성
- 커스텀예외 →  로그 출력 (warn)
- 그 외 모든 Exception → 500 응답 처리 및 로그 출력 (error)
- 사용자에겐 오류 상세를 노출하지 않고 고정 메시지 제공
- 로깅 레벨을 상황별로 구분 적용 (warn / error)
```
 {
    "status": 404,
    "message": "해당 방이 존재하지 않습니다.",
    "data": null
}
```
<br><br>

## 참고 사항
- 로그백 설정은 추후 예정

<br><br>

## 관련 이슈

- Close #24 

<br><br>
