### PR TITLE
feat: RoomMember 참여/퇴장 기능 및 방장 위임 로직 구현

### DIFF
--- a/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.swu.global.exception;
 
 import com.swu.global.response.ApiResponse;
+import com.swu.room.exception.AlreadyJoinedRoomException;
+import com.swu.room.exception.NotJoinedRoomException;
+import com.swu.room.exception.RoomFullException;
 import com.swu.room.exception.RoomNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,6 +22,31 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.error(HttpStatus.NOT_FOUND, e.getMessage()));
     }
+
+    @ExceptionHandler(AlreadyJoinedRoomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAlreadyJoinedRoomException(AlreadyJoinedRoomException e) {
+        log.warn("AlreadyJoinedRoomException: {}", e.getMessage()); //
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
+    }
+
+    @ExceptionHandler(RoomFullException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRoomFullException(RoomFullException e) {
+        log.warn("RoomFullException: {}", e.getMessage()); //
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
+    }
+
+    @ExceptionHandler(NotJoinedRoomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNotJoinedRoomException(NotJoinedRoomException e) {
+        log.warn("NotJoinedRoomException: {}", e.getMessage()); //
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
+    }
+
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGeneralException(Exception e) {

--- a/backend/src/main/java/com/swu/room/controller/RoomController.java
+++ b/backend/src/main/java/com/swu/room/controller/RoomController.java
@@ -1,5 +1,6 @@
 package com.swu.room.controller;
 
+import com.swu.auth.domain.CustomUserDetails;
 import com.swu.global.response.ApiResponse;
 import com.swu.room.dto.request.RoomRequest;
 import com.swu.room.dto.response.RoomResponse;
@@ -7,12 +8,11 @@ import com.swu.room.service.RoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Controller
 @RestController
 @RequestMapping("/room")
 @RequiredArgsConstructor
@@ -22,8 +22,10 @@ public class RoomController {
 
     @Operation(summary = "스터디 방 생성", description = "방을 생성합니다.")
     @PostMapping
-    public ResponseEntity<ApiResponse<RoomResponse>> createRoom(@RequestBody RoomRequest request) {
-        roomService.createRoom(request);
+    public ResponseEntity<ApiResponse<RoomResponse>> createRoom(
+            @RequestBody RoomRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        roomService.createRoom(request, userDetails.getUser());
         return ResponseEntity.ok(ApiResponse.ok("방 생성 성공", null));
     }
 

--- a/backend/src/main/java/com/swu/room/controller/RoomController.java
+++ b/backend/src/main/java/com/swu/room/controller/RoomController.java
@@ -29,7 +29,7 @@ public class RoomController {
         return ResponseEntity.ok(ApiResponse.ok("방 생성 성공", null));
     }
 
-    @Operation(summary = "전체 방 목록 조회", description = "현재 존재하는 모든 스터디 방 목록을 조회합니다.")
+    @Operation(summary = "전체 방 목록 조회", description = "활성화된 모든 방 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<List<RoomResponse>>> getAllRooms() {
         List<RoomResponse> rooms = roomService.getAllRooms();
@@ -37,7 +37,7 @@ public class RoomController {
     }
 
 
-    @Operation(summary = "단일 방 조회", description = "roomId로 특정 방 정보를 조회합니다.")
+    @Operation(summary = "단일 방 조회", description = "roomId로 활성화된 특정 방 정보를 조회합니다.")
     @GetMapping("/{roomId}")
     public ResponseEntity<ApiResponse<RoomResponse>> getRoom(@PathVariable Long roomId) {
         RoomResponse room = roomService.getRoom(roomId);

--- a/backend/src/main/java/com/swu/room/controller/RoomMemberController.java
+++ b/backend/src/main/java/com/swu/room/controller/RoomMemberController.java
@@ -1,0 +1,44 @@
+package com.swu.room.controller;
+
+
+import com.swu.auth.domain.CustomUserDetails;
+import com.swu.global.response.ApiResponse;
+import com.swu.room.service.RoomMemberService;
+import com.swu.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/room")
+@RequiredArgsConstructor
+public class RoomMemberController {
+
+    private final RoomMemberService roomMemberService;
+
+    @Operation(summary = "방 참여", description = "특정 스터디 방에 참여합니다.")
+    @PostMapping("/{roomId}/join")
+    public ResponseEntity<ApiResponse<Void>> joinRoom(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        User user = userDetails.getUser();
+        roomMemberService.joinRoom(roomId, userDetails.getUser());
+        return ResponseEntity.ok(ApiResponse.ok("방 참여 성공.", null));
+    }
+
+    @Operation(summary = "방 나가기", description = "특정 스터디 방에서 나갑니다.")
+    @PostMapping("/{roomId}/exit")
+    public ResponseEntity<ApiResponse<Void>> exitRoom(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        roomMemberService.exitRoom(roomId, userDetails.getUser());
+        return ResponseEntity.ok(ApiResponse.ok("방 나가기 성공.", null));
+    }
+}

--- a/backend/src/main/java/com/swu/room/controller/RoomMemberController.java
+++ b/backend/src/main/java/com/swu/room/controller/RoomMemberController.java
@@ -3,16 +3,16 @@ package com.swu.room.controller;
 
 import com.swu.auth.domain.CustomUserDetails;
 import com.swu.global.response.ApiResponse;
+import com.swu.room.dto.response.RoomMemberResponse;
 import com.swu.room.service.RoomMemberService;
 import com.swu.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/room")
@@ -40,5 +40,14 @@ public class RoomMemberController {
 
         roomMemberService.exitRoom(roomId, userDetails.getUser());
         return ResponseEntity.ok(ApiResponse.ok("방 나가기 성공.", null));
+    }
+
+    @Operation(summary = "방 참여자 목록 조회", description = "특정 스터디 방의 참여자 목록을 조회합니다.")
+    @GetMapping("/{roomId}/members")
+    public ResponseEntity<ApiResponse<List<RoomMemberResponse>>> getMembers(
+            @PathVariable Long roomId) {
+
+        List<RoomMemberResponse> members = roomMemberService.getMembers(roomId);
+        return ResponseEntity.ok(ApiResponse.ok("참여자 목록 조회 성공", members));
     }
 }

--- a/backend/src/main/java/com/swu/room/domain/Room.java
+++ b/backend/src/main/java/com/swu/room/domain/Room.java
@@ -34,15 +34,15 @@ public class Room {
     @Column(nullable = false)
     private int breakMinute;
 
-    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<RoomMember> members = new ArrayList<>();
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bgm_id")
     private Bgm bgm;
 
-    public void addMember(RoomMember member) {
-        members.add(member);
-        member.setRoom(this);
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    public void setDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
 }

--- a/backend/src/main/java/com/swu/room/domain/RoomMember.java
+++ b/backend/src/main/java/com/swu/room/domain/RoomMember.java
@@ -37,4 +37,8 @@ public class RoomMember {
     void setRoom(Room room) {
         this.room = room;
     }
+
+    public void exit() {
+        this.exitedAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/swu/room/domain/RoomMember.java
+++ b/backend/src/main/java/com/swu/room/domain/RoomMember.java
@@ -41,4 +41,8 @@ public class RoomMember {
     public void exit() {
         this.exitedAt = LocalDateTime.now();
     }
+
+    public void setHost(boolean isHost) {
+        this.isHost = isHost;
+    }
 }

--- a/backend/src/main/java/com/swu/room/dto/response/RoomMemberResponse.java
+++ b/backend/src/main/java/com/swu/room/dto/response/RoomMemberResponse.java
@@ -1,0 +1,10 @@
+package com.swu.room.dto.response;
+
+import java.time.LocalDateTime;
+
+public record RoomMemberResponse(
+        Long userId,
+        String nickname,
+        boolean isHost,
+        LocalDateTime joinedAt
+) {}

--- a/backend/src/main/java/com/swu/room/exception/AlreadyJoinedRoomException.java
+++ b/backend/src/main/java/com/swu/room/exception/AlreadyJoinedRoomException.java
@@ -1,0 +1,7 @@
+package com.swu.room.exception;
+
+public class AlreadyJoinedRoomException extends RuntimeException {
+    public AlreadyJoinedRoomException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/swu/room/exception/NotJoinedRoomException.java
+++ b/backend/src/main/java/com/swu/room/exception/NotJoinedRoomException.java
@@ -1,0 +1,7 @@
+package com.swu.room.exception;
+
+public class NotJoinedRoomException extends RuntimeException {
+    public NotJoinedRoomException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/swu/room/exception/RoomFullException.java
+++ b/backend/src/main/java/com/swu/room/exception/RoomFullException.java
@@ -1,0 +1,7 @@
+package com.swu.room.exception;
+
+public class RoomFullException extends RuntimeException {
+    public RoomFullException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/swu/room/repository/RoomMemberRepository.java
+++ b/backend/src/main/java/com/swu/room/repository/RoomMemberRepository.java
@@ -1,7 +1,14 @@
 package com.swu.room.repository;
 
+import com.swu.room.domain.Room;
 import com.swu.room.domain.RoomMember;
+import com.swu.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
+    boolean existsByRoomAndUserAndExitedAtIsNull(Room room, User user);
+    Optional<RoomMember> findByRoomAndUserAndExitedAtIsNull(Room room, User user);
+    int countByRoomAndExitedAtIsNull(Room room);
 }

--- a/backend/src/main/java/com/swu/room/repository/RoomMemberRepository.java
+++ b/backend/src/main/java/com/swu/room/repository/RoomMemberRepository.java
@@ -5,10 +5,12 @@ import com.swu.room.domain.RoomMember;
 import com.swu.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
     boolean existsByRoomAndUserAndExitedAtIsNull(Room room, User user);
     Optional<RoomMember> findByRoomAndUserAndExitedAtIsNull(Room room, User user);
     int countByRoomAndExitedAtIsNull(Room room);
+    List<RoomMember> findByRoomAndExitedAtIsNull(Room room);
 }

--- a/backend/src/main/java/com/swu/room/repository/RoomRepository.java
+++ b/backend/src/main/java/com/swu/room/repository/RoomRepository.java
@@ -3,5 +3,10 @@ package com.swu.room.repository;
 import com.swu.room.domain.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface RoomRepository extends JpaRepository<Room, Long> {
+    List<Room> findByIsDeletedFalse();
+    Optional<Room> findByIdAndIsDeletedFalse(Long roomId);
 }

--- a/backend/src/main/java/com/swu/room/service/RoomMemberService.java
+++ b/backend/src/main/java/com/swu/room/service/RoomMemberService.java
@@ -14,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -25,12 +27,12 @@ public class RoomMemberService {
     @Transactional
     public void joinRoom(Long roomId, User user) {
 
-        Room room = roomRepository.findById(roomId)
+        Room room = roomRepository.findByIdAndIsDeletedFalse(roomId)
                 .orElseThrow(() -> new RoomNotFoundException("해당 방이 존재하지 않습니다."));
 
         boolean isAlreadyJoined = roomMemberRepository.existsByRoomAndUserAndExitedAtIsNull(room, user);
         if (isAlreadyJoined) {
-            throw new AlreadyJoinedRoomException("이미 방에 참여 중인  사용자입니다.");
+            throw new AlreadyJoinedRoomException("이미 방에 참여 중인 사용자입니다.");
         }
 
         int currentCount = roomMemberRepository.countByRoomAndExitedAtIsNull(room);
@@ -49,13 +51,33 @@ public class RoomMemberService {
 
     @Transactional
     public void exitRoom(Long roomId, User user) {
-        Room room = roomRepository.findById(roomId)
+        Room room = roomRepository.findByIdAndIsDeletedFalse(roomId)
                 .orElseThrow(() -> new RoomNotFoundException("해당 방이 존재하지 않습니다."));
 
         RoomMember roomMember = roomMemberRepository.findByRoomAndUserAndExitedAtIsNull(room, user)
                 .orElseThrow(() -> new NotJoinedRoomException("방에 참여하지 않은 사용자입니다."));
 
         roomMember.exit();
+
+        boolean isHost = roomMember.isHost();
+        if (isHost) roomMember.setHost(false);
+
         roomMemberRepository.save(roomMember);
+
+        if (isHost) delegateHost(room);
+
+}
+
+    private void delegateHost(Room room) {
+        List<RoomMember> others = roomMemberRepository.findByRoomAndExitedAtIsNull(room);
+
+        if (!others.isEmpty()) {
+            RoomMember newHost = others.get(0); // 현재는 첫번째 유저가 방장이 됨
+            newHost.setHost(true);
+            roomMemberRepository.save(newHost);
+        } else { // 방에 남아있는 유저가 없을 경우 방 삭제
+            room.setDeleted(true);
+            roomRepository.save(room);
+        }
     }
 }

--- a/backend/src/main/java/com/swu/room/service/RoomMemberService.java
+++ b/backend/src/main/java/com/swu/room/service/RoomMemberService.java
@@ -1,0 +1,61 @@
+package com.swu.room.service;
+
+import com.swu.room.domain.Room;
+import com.swu.room.domain.RoomMember;
+import com.swu.room.exception.AlreadyJoinedRoomException;
+import com.swu.room.exception.NotJoinedRoomException;
+import com.swu.room.exception.RoomFullException;
+import com.swu.room.exception.RoomNotFoundException;
+import com.swu.room.repository.RoomMemberRepository;
+import com.swu.room.repository.RoomRepository;
+import com.swu.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoomMemberService {
+
+    private final RoomMemberRepository roomMemberRepository;
+    private final RoomRepository roomRepository;
+
+    @Transactional
+    public void joinRoom(Long roomId, User user) {
+
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new RoomNotFoundException("해당 방이 존재하지 않습니다."));
+
+        boolean isAlreadyJoined = roomMemberRepository.existsByRoomAndUserAndExitedAtIsNull(room, user);
+        if (isAlreadyJoined) {
+            throw new AlreadyJoinedRoomException("이미 방에 참여 중인  사용자입니다.");
+        }
+
+        int currentCount = roomMemberRepository.countByRoomAndExitedAtIsNull(room);
+        if (currentCount >= room.getMaxCapacity()) {
+            throw new RoomFullException("방이 가득 차서 더 이상 참여할 수 없습니다.");
+        }
+
+        RoomMember roomMember = RoomMember.builder()
+                .room(room)
+                .user(user)
+                .isHost(false)
+                .build();
+
+        roomMemberRepository.save(roomMember);
+    }
+
+    @Transactional
+    public void exitRoom(Long roomId, User user) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new RoomNotFoundException("해당 방이 존재하지 않습니다."));
+
+        RoomMember roomMember = roomMemberRepository.findByRoomAndUserAndExitedAtIsNull(room, user)
+                .orElseThrow(() -> new NotJoinedRoomException("방에 참여하지 않은 사용자입니다."));
+
+        roomMember.exit();
+        roomMemberRepository.save(roomMember);
+    }
+}

--- a/backend/src/main/java/com/swu/room/service/RoomService.java
+++ b/backend/src/main/java/com/swu/room/service/RoomService.java
@@ -44,14 +44,14 @@ public class RoomService {
 
     @Transactional
     public List<RoomResponse> getAllRooms() {
-        return roomRepository.findAll().stream()
+        return roomRepository.findByIsDeletedFalse().stream()
                 .map(this::toRoomResponse)
                 .toList();
     }
 
     @Transactional
     public RoomResponse getRoom(Long roomId) {
-        Room room = roomRepository.findById(roomId)
+        Room room = roomRepository.findByIdAndIsDeletedFalse(roomId)
                 .orElseThrow(() -> new RoomNotFoundException("해당 방이 존재하지 않습니다."));
         return toRoomResponse(room);
     }

--- a/backend/src/main/java/com/swu/room/service/RoomService.java
+++ b/backend/src/main/java/com/swu/room/service/RoomService.java
@@ -23,7 +23,7 @@ public class RoomService {
     private final RoomMemberRepository roomMemberRepository;
 
     @Transactional
-    public void createRoom(RoomRequest request) {
+    public void createRoom(RoomRequest request, User user) {
         Room room = Room.builder()
                 .title(request.title())
                 .maxCapacity(request.maxCapacity())
@@ -32,6 +32,14 @@ public class RoomService {
                 .build();
 
         roomRepository.save(room);
+
+        RoomMember roomMember = RoomMember.builder()
+                .room(room)
+                .user(user)
+                .isHost(true)
+                .build();
+
+        roomMemberRepository.save(roomMember);
     }
 
     @Transactional

--- a/backend/src/main/java/com/swu/room/service/RoomService.java
+++ b/backend/src/main/java/com/swu/room/service/RoomService.java
@@ -1,10 +1,13 @@
 package com.swu.room.service;
 
 import com.swu.room.domain.Room;
+import com.swu.room.domain.RoomMember;
 import com.swu.room.dto.request.RoomRequest;
 import com.swu.room.dto.response.RoomResponse;
 import com.swu.room.exception.RoomNotFoundException;
+import com.swu.room.repository.RoomMemberRepository;
 import com.swu.room.repository.RoomRepository;
+import com.swu.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +20,7 @@ import java.util.List;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final RoomMemberRepository roomMemberRepository;
 
     @Transactional
     public void createRoom(RoomRequest request) {
@@ -45,13 +49,15 @@ public class RoomService {
     }
 
     private RoomResponse toRoomResponse(Room room) {
+        int currentMembers = roomMemberRepository.countByRoomAndExitedAtIsNull(room);
+
         return new RoomResponse(
                 room.getId(),
                 room.getTitle(),
                 room.getMaxCapacity(),
                 room.getFocusMinute(),
                 room.getBreakMinute(),
-                room.getMembers().size(),
+                currentMembers,
                 room.getCreatedAt(),
                 room.getBgm() != null ? room.getBgm().getTitle() : null
         );


### PR DESCRIPTION
## 요약
RoomMember 도메인에 대한 기능 구현을 완료.
방 참여, 나가기, 방장 위임 등의 로직을 포함하며, 소프트 딜리트 방식으로 방 삭제 처리도 포함.
<br><br>

## 작업 내용
- RoomMember 참여 API (`POST /room/{roomId}/join`)
- RoomMember 나가기 API (`POST /room/{roomId}/exit`)
- 방장일 경우 나가기 시 자동 방장 위임
    - 남은 인원이 없다면 해당 Room은 soft delete 처리
- 방 가득 찼을 때 접속, 존재하지 않거나 삭제된 방 접속 예외 처리
- 관련 커스텀 예외 처리
    - RoomNotFoundException
    - AlreadyJoinedRoomException
    - RoomFullException
    - NotJoinedRoomException
- soft delete 방식으로 Room 삭제 처리 (Room 엔터티에 `isDeleted` 필드 추가)
- 참여자 목록 조회 API (`GET /room/{roomId}/members`)
    - `RoomMemberResponse` DTO로 반환
    - 방에 참여중(exitedAt == null)인 인원만 조회
<br><br>

## 참고 사항
- `Room` ↔ `RoomMember` 연관관계는 RoomMember → Room 단방향만 유지
- 단순 조회용 응답 DTO 분리 (`RoomMemberResponse`)
<br><br>

## 추후예정
- 방 정보 수정 API – 별도 브랜치에서 처리 예정
<br><br>

## 관련 이슈

- Close #26 

<br><br>
