### PR TITLE
feat: WebRTC 시그널링 서버 구현

### DIFF
--- a/backend/src/main/java/com/swu/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/swu/global/config/WebSocketConfig.java
@@ -16,11 +16,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         config.enableSimpleBroker("/sub");
 
         // 클라이언트에서 메시지 보낼 때 prefix
-        config.setApplicationDestinationPrefixes("/app");
+        config.setApplicationDestinationPrefixes("/pub");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws/chat").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
     }
 }

--- a/backend/src/main/java/com/swu/room/controller/SignalingController.java
+++ b/backend/src/main/java/com/swu/room/controller/SignalingController.java
@@ -1,0 +1,37 @@
+package com.swu.room.controller;
+
+import com.swu.auth.domain.CustomUserDetails;
+import com.swu.room.dto.message.SignalingMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import java.util.List;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class SignalingController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/signal") // 클라이언트 -> /pub/signal
+    public void handleSignal(@Payload SignalingMessage message) {
+
+        if (message.getRoomId() == null || message.getRoomId() <= 0) {
+            throw new IllegalArgumentException("roomId는 0보다 커야 합니다.");
+        }
+        if (!List.of("offer", "answer", "ice", "join", "leave").contains(message.getType())) {
+            throw new IllegalArgumentException("type이 잘못되었습니다.");
+        }
+
+        log.info("Signaling message 수신 : {}", message);
+
+        String destination = "/sub/room/" + message.getRoomId();
+        messagingTemplate.convertAndSend(destination,  message);
+    }
+}

--- a/backend/src/main/java/com/swu/room/dto/message/SignalingMessage.java
+++ b/backend/src/main/java/com/swu/room/dto/message/SignalingMessage.java
@@ -1,0 +1,9 @@
+package com.swu.room.dto.message;
+
+public record SignalingMessage(
+        String type,
+        Long roomId,
+        Long senderId,
+        String senderNickname,
+        Object data
+) {}


### PR DESCRIPTION
## 요약
STOMP 기반 WebSocket 시그널링 서버의 기본 구조를 구현함.  
WebRTC 연결을 위한 offer, answer, ice, join, leave 메시지 처리 가능.
<br><br>

## 작업 내용
- SignalingMessage DTO 클래스 생성
  - type, roomId, senderId, senderNickname, data 포함
- SignalingController 작성
  - /pub/signal 경로로 들어온 메시지를 /sub/room/{roomId}로 전달
  - 메시지 타입 /roomId 유효성 검증 포함
- WebSocketConfig 작성
  - STOMP를 위한 WebSocket 설정 구성
  - SockJS 엔드포인트 `/ws` 설정
  - prefix: `/pub`, `/sub`
<br><br>

## 참고 사항
- 아직 senderId, senderNickname은 인증 정보로부터 설정하지 않고 프론트에서 전달받음

<br><br>

## 관련 이슈

- Close #21 

<br><br>
