### PR TITLE
feat: STOMP 기반 시그널링에 JWT 인증 로직 및 예외 처리 적용

### DIFF
--- a/backend/src/main/java/com/swu/global/config/StompJwtInterceptor.java
+++ b/backend/src/main/java/com/swu/global/config/StompJwtInterceptor.java
@@ -1,0 +1,72 @@
+package com.swu.global.config;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import com.swu.auth.domain.CustomUserDetails;
+import com.swu.auth.jwt.JWTUtil;
+import com.swu.user.domain.User;
+import com.swu.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ - WebSocket STOMP 연결 요청 시 Authorization 헤더의 JWT 토큰을 검증하고,
+ - 유효한 경우 인증 객체를 생성하여 STOMP 세션에 주입하는 인터셉터.
+**/
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompJwtInterceptor implements ChannelInterceptor {
+
+    private final JWTUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        // STOMP 메시지의 헤더 정보 추출
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        // CONNECT 명령일 때만 JWT 인증 처리
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            // Authorization 헤더에서 토큰 추출
+            String token = accessor.getFirstNativeHeader("Authorization");
+            
+            if (token != null && token.startsWith("Bearer ")) {
+                token = token.substring(7);
+                
+                // 토큰 만료 여부 확인
+                if (jwtUtil.isExpired(token)) {
+                    log.warn("만료된 토큰으로 WebSocket 연결 시도");
+                    throw new IllegalArgumentException("JWT 토큰이 만료되었습니다.");
+                }
+
+                // 토큰에서 사용자 ID 추출 및 DB 조회
+                Long userId = (long)jwtUtil.getId(token);
+                User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+       
+                // CustomUserDetails 및 인증 객체 생성
+                CustomUserDetails customUserDetails = new CustomUserDetails(user);
+                UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(customUserDetails, token, customUserDetails.getAuthorities());
+
+                // WebSocket 세션에 인증 정보 설정
+                accessor.setUser(authentication);
+
+                log.debug("WebSocket 인증 성공: {}", user.getNickname());
+            } else {
+                log.warn("Authorization 헤더가 누락되었거나 형식이 잘못됨");
+            }
+        }
+        // 메시지를 다음 단계로 전달!!
+        return message;
+    }
+}

--- a/backend/src/main/java/com/swu/global/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/swu/global/config/WebMvcConfig.java
@@ -13,6 +13,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedOriginPatterns("*") // 개발 중이니까 모든 origin 허용
                 .allowedMethods("*")        // GET, POST 등 전부 허용
                 .allowedHeaders("*")
+                .exposedHeaders("Authorization") // Authorization 헤더를 클라이언트에 노출
                 .allowCredentials(true);    // 쿠키 허용 (선택사항)
     }
 }

--- a/backend/src/main/java/com/swu/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/swu/global/config/WebSocketConfig.java
@@ -2,13 +2,18 @@ package com.swu.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.web.socket.config.annotation.*;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
-@Configuration // 스프링 설정 클래스
+@Configuration
 @EnableWebSocketMessageBroker // 웹소켓 + STOMP 활성화
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompJwtInterceptor stompJwtInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -21,6 +26,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
     }
+
+    // WebSocket 연결 시 클라이언트의 STOMP 메시지를 가로채어 JWT 인증을 처리하기 위한 인터셉터 등록
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompJwtInterceptor); 
+}
 }

--- a/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
@@ -8,12 +8,29 @@ import com.swu.room.exception.RoomNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .findFirst()
+            .map(FieldError::getDefaultMessage)
+            .orElse("유효성 검사에 실패했습니다.");
+        
+        log.warn("Validation error: {}", errorMessage);
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(HttpStatus.BAD_REQUEST, errorMessage));
+    }
 
     @ExceptionHandler(RoomNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleRoomNotFoundException(RoomNotFoundException e) {
@@ -25,7 +42,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AlreadyJoinedRoomException.class)
     public ResponseEntity<ApiResponse<Void>> handleAlreadyJoinedRoomException(AlreadyJoinedRoomException e) {
-        log.warn("AlreadyJoinedRoomException: {}", e.getMessage()); //
+        log.warn("AlreadyJoinedRoomException: {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
@@ -33,7 +50,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RoomFullException.class)
     public ResponseEntity<ApiResponse<Void>> handleRoomFullException(RoomFullException e) {
-        log.warn("RoomFullException: {}", e.getMessage()); //
+        log.warn("RoomFullException: {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
@@ -41,16 +58,31 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotJoinedRoomException.class)
     public ResponseEntity<ApiResponse<Void>> handleNotJoinedRoomException(NotJoinedRoomException e) {
-        log.warn("NotJoinedRoomException: {}", e.getMessage()); //
+        log.warn("NotJoinedRoomException: {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("IllegalArgumentException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<ApiResponse<Void>> handleSecurityException(SecurityException e) {
+        log.warn("SecurityException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error(HttpStatus.FORBIDDEN, e.getMessage()));
+    }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGeneralException(Exception e) {
-        log.error("Unexpected error occurred", e); //
+        log.error("Unexpected error occurred", e);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."));

--- a/backend/src/main/java/com/swu/room/controller/SignalingController.java
+++ b/backend/src/main/java/com/swu/room/controller/SignalingController.java
@@ -2,15 +2,20 @@ package com.swu.room.controller;
 
 import com.swu.auth.domain.CustomUserDetails;
 import com.swu.room.dto.message.SignalingMessage;
+import com.swu.room.service.RoomService;
+import com.swu.user.domain.User;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.security.Principal;
+
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Controller;
-
-import java.util.List;
 
 @Slf4j
 @Controller
@@ -18,20 +23,40 @@ import java.util.List;
 public class SignalingController {
 
     private final SimpMessagingTemplate messagingTemplate;
+    private final RoomService roomService;
 
-    @MessageMapping("/signal") // 클라이언트 -> /pub/signal
-    public void handleSignal(@Payload SignalingMessage message) {
+    @MessageMapping("/signal")
+    public void handleSignal(@Payload @Valid SignalingMessage message, Principal principal) {
+        try {
+            if (!(principal instanceof UsernamePasswordAuthenticationToken authToken)) {
+                throw new SecurityException("인증되지 않은 사용자입니다.");
+            }
+            
+            // 인증된 사용자 정보 추출
+            CustomUserDetails userDetails = (CustomUserDetails) authToken.getPrincipal();
+            User user = userDetails.getUser();
 
-        if (message.getRoomId() == null || message.getRoomId() <= 0) {
-            throw new IllegalArgumentException("roomId는 0보다 커야 합니다.");
+            // 방 접근 권한 검사
+            if (!roomService.hasAccessToRoom(message.roomId(), user)) {
+                throw new SecurityException("방에 입장할 권한이 없습니다.");
+            }
+
+            log.debug("시그널 메시지 수신 - 타입: {}, 방: {}, 발신자: {}", 
+                    message.type(), message.roomId(), message.senderNickname());
+
+            String destination = "/sub/room/" + message.roomId();
+            messagingTemplate.convertAndSend(destination, message);
+
+        } catch (Exception e) {
+            log.error("시그널 처리 중 오류 발생: {}", e.getMessage());
+            SignalingMessage errorMessage = SignalingMessage.createError(
+                message.roomId(),
+                message.senderId(),
+                message.senderNickname(),
+                e.getMessage()
+            );
+            messagingTemplate.convertAndSend("/sub/room/" + message.roomId(), errorMessage);
         }
-        if (!List.of("offer", "answer", "ice", "join", "leave").contains(message.getType())) {
-            throw new IllegalArgumentException("type이 잘못되었습니다.");
-        }
-
-        log.info("Signaling message 수신 : {}", message);
-
-        String destination = "/sub/room/" + message.getRoomId();
-        messagingTemplate.convertAndSend(destination,  message);
     }
+
 }

--- a/backend/src/main/java/com/swu/room/dto/message/SignalingMessage.java
+++ b/backend/src/main/java/com/swu/room/dto/message/SignalingMessage.java
@@ -1,9 +1,38 @@
 package com.swu.room.dto.message;
 
+import java.util.Set;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
 public record SignalingMessage(
-        String type,
-        Long roomId,
-        Long senderId,
-        String senderNickname,
-        Object data
-) {}
+    @NotBlank(message = "메시지 타입은 필수입니다.")
+    String type,
+    
+    @NotNull(message = "방 ID는 필수입니다.")
+    @Positive(message = "방 ID는 양수여야 합니다.")
+    Long roomId,
+    
+    @NotNull(message = "발신자 ID는 필수입니다.")
+    @Positive(message = "발신자 ID는 양수여야 합니다.")
+    Long senderId,
+    
+    @NotBlank(message = "발신자 닉네임은 필수입니다.")
+    String senderNickname,
+    
+    @NotNull(message = "데이터는 필수입니다.")
+    Object data
+) {
+    private static final Set<String> VALID_TYPES = Set.of("offer", "answer", "ice", "join", "leave","error");
+    
+    public SignalingMessage {
+        if (!VALID_TYPES.contains(type)) {
+            throw new IllegalArgumentException("잘못된 메시지 타입입니다. : " + type);
+        }
+    }
+    
+    public static SignalingMessage createError(Long roomId, Long senderId, String senderNickname, String errorMessage) {
+        return new SignalingMessage("error", roomId, senderId, senderNickname, errorMessage);
+    }
+} 

--- a/backend/src/main/java/com/swu/room/service/RoomService.java
+++ b/backend/src/main/java/com/swu/room/service/RoomService.java
@@ -9,11 +9,13 @@ import com.swu.room.repository.RoomMemberRepository;
 import com.swu.room.repository.RoomRepository;
 import com.swu.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -69,6 +71,27 @@ public class RoomService {
                 room.getCreatedAt(),
                 room.getBgm() != null ? room.getBgm().getTitle() : null
         );
+    }
+
+    public boolean hasAccessToRoom(Long roomId, User user) {
+        try {
+            // 방이 존재하는지 확인
+            Room room = roomRepository.findByIdAndIsDeletedFalse(roomId)
+                .orElseThrow(() -> new RoomNotFoundException("해당 방이 존재하지 않습니다."));
+            
+            // 해당 방의 멤버 정보 조회
+            Boolean isJoined = roomMemberRepository.existsByRoomAndUserAndExitedAtIsNull(room, user);            
+            
+            // 멤버가 존재하면 접근 허용
+            boolean hasAccess = isJoined;
+            
+            log.debug("접근 권한 확인 - 방: {}, 사용자: {}, 접근 가능: {}", roomId, user.getId(), hasAccess);
+            
+            return hasAccess;
+        } catch (Exception e) {
+            log.error("방 접근 권한 확인 중 오류 발생 - 방: {}, 사용자: {}, 오류: {}", roomId, user.getId(), e.getMessage());
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
## 요약
WebSocket STOMP 연결 시 Authorization 헤더의 JWT를 검증하고,
정상 사용자일 경우 인증 객체를 STOMP 세션에 주입하는 인터셉터를 구현했다.
또한, signaling 메시지 처리 시 방 접근 권한 확인 및 관련 예외 처리를 추가했다.
<br><br>

## 작업 내용
- StompJwtInterceptor 생성 및 WebSocket 연결 시 JWT 검증 로직 구현
- WebSocketConfig에 interceptor 등록
- signaling 메시지 전송 시 사용자 인증 및 방 접근 권한 체크 (`SignalingController`)
- RoomService에 hasAccessToRoom() 로직 추가
- GlobalExceptionHandler에 다음 예외 추가 처리
  - `MethodArgumentNotValidException`
  - `IllegalArgumentException`
  - `SecurityException`
- SignalingMessage DTO 유효성 검증 추가 및 createError 정적 팩토리 메서드 정의

<br><br>

## 참고 사항
- 현재는 메시지 수신마다 방 접근 권한을 DB에서 체크하고 있음 (추후 캐싱 고려 가능)
- `Authorization` 헤더 노출을 위해 WebMvc 설정에 `.exposedHeaders("Authorization")` 추가함
- 채팅 메시지는 아직 인증 없이 처리되며, 이후 signaling 구조와 통합 가능성 있음

<br><br>

## 관련 이슈

- Close 이슈없음

<br><br>
