### PR TITLE
refactor: 채팅 메시지를 Redis에 저장하고 Pub/Sub 방식으로 전송하도록 구조 개선

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	// Validation API
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/backend/src/main/java/com/swu/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/swu/global/config/RedisConfig.java
@@ -1,0 +1,93 @@
+package com.swu.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+ import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swu.room.listener.RedisMessageSubscriber;
+
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * Redis 설정 클래스
+ * - RedisConnectionFactory와 RedisTemplate Bean을 등록하여
+ *   Redis 서버와의 연결 및 데이터 입출력에 사용할 수 있도록 구성함
+ */
+@Configuration
+public class RedisConfig {
+    
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+    /**
+     * Redis 연결 팩토리 빈 등록
+     * - Lettuce 클라이언트를 사용하여 Redis에 연결함
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    /**
+     * RedisTemplate 빈 등록
+     * - key와 value를 모두 문자열(String)로 직렬화하여 저장
+     * - Redis 연결 팩토리를 주입받아 사용
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return redisTemplate;
+    }
+
+    /**
+     * RedisMessageListenerContainer 빈 등록
+     * Redis 메시지 수신 컨테이너를 정의함
+     * RedisMessageSubscriber를 등록하고, 채널 주체를 지정함
+     */
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            RedisMessageSubscriber redisMessageSubscriber,
+            ChannelTopic topic) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(redisMessageSubscriber, topic); // 직접 등록
+        return container;
+    }
+
+
+    /*
+     * /pub/sub 모델에서 Redis 채널을 지정하기 위한 채널 주체(topic) 객체
+     * 채널 주체는 메시지를 발행하고 구독하는 데 사용되는 채널의 이름을 정의함
+     */
+    @Bean
+    public ChannelTopic channelTopic() {
+        return new ChannelTopic("chat");
+    }
+}

--- a/backend/src/main/java/com/swu/room/controller/ChatController.java
+++ b/backend/src/main/java/com/swu/room/controller/ChatController.java
@@ -7,12 +7,12 @@ import java.security.Principal;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Controller;
 
 import com.swu.auth.domain.CustomUserDetails;
 import com.swu.room.dto.message.ChatMessage;
+import com.swu.room.service.ChatService;
 import com.swu.room.service.RoomService;
 import com.swu.user.domain.User;
 
@@ -23,34 +23,30 @@ import jakarta.validation.Valid;
 @RequiredArgsConstructor
 public class ChatController {
 
-    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatService chatService;
     private final RoomService roomService;
     @MessageMapping("/chat/message")
     public void handleChatMessage(@Payload @Valid ChatMessage message, Principal principal) {
-            if (!(principal instanceof UsernamePasswordAuthenticationToken authToken)) {
-                throw new SecurityException("인증되지 않은 사용자입니다.");
-            }
+        if (!(principal instanceof UsernamePasswordAuthenticationToken authToken)) {
+            throw new SecurityException("인증되지 않은 사용자입니다.");
+        }
 
-            CustomUserDetails userDetails = (CustomUserDetails) authToken.getPrincipal();
-            User user = userDetails.getUser();
+        CustomUserDetails userDetails = (CustomUserDetails) authToken.getPrincipal();
+        User user = userDetails.getUser();
 
-            if (!roomService.hasAccessToRoom(message.roomId(), user)) {
-                throw new SecurityException("방에 입장할 권한이 없습니다.");
-            }
-            
-            // 발신자 정보 보정
-            ChatMessage updatedMessage = new ChatMessage(
-                message.type(),
-                message.roomId(),
-                user.getId(),
-                user.getNickname(),
-                message.message()
-            );
-
-            log.debug("채팅 메시지 수신 - 타입: {}, 방: {}, 발신자: {}", 
-                updatedMessage.type(), updatedMessage.roomId(), updatedMessage.senderNickname());
-
-            String destination = "/sub/chat/room/" + message.roomId();
-            messagingTemplate.convertAndSend(destination, updatedMessage);        
+        if (!roomService.hasAccessToRoom(message.roomId(), user)) {
+            throw new SecurityException("방에 입장할 권한이 없습니다.");
+        }
+        
+        // 발신자 정보 보정
+        ChatMessage updatedMessage = new ChatMessage(
+            message.type(),
+            message.roomId(),
+            user.getId(),
+            user.getNickname(),
+            message.message()
+        );
+    
+        chatService.sendMessage(updatedMessage);
     }
 }

--- a/backend/src/main/java/com/swu/room/listener/RedisMessageSubscriber.java
+++ b/backend/src/main/java/com/swu/room/listener/RedisMessageSubscriber.java
@@ -1,0 +1,38 @@
+package com.swu.room.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swu.room.dto.message.ChatMessage;
+
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisMessageSubscriber implements MessageListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(@NonNull Message message, @Nullable byte[] pattern) {
+        try {
+            String body = new String(message.getBody());
+            ChatMessage chatMessage = objectMapper.readValue(body, ChatMessage.class);
+
+            String destination = "/sub/chat/room/" + chatMessage.roomId();
+            messagingTemplate.convertAndSend(destination, chatMessage);
+            log.debug("Redis로부터 수신한 메시지를 전송함 - 방: {}", chatMessage.roomId());
+
+        } catch (Exception e) {
+            log.error("Redis 메시지 수신 중 오류 발생", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/swu/room/service/ChatService.java
+++ b/backend/src/main/java/com/swu/room/service/ChatService.java
@@ -1,0 +1,29 @@
+package com.swu.room.service;
+
+import com.swu.room.dto.message.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ChannelTopic channelTopic;
+
+    public void sendMessage(ChatMessage message) {
+        saveMessage(message);
+        // chat 채널에 메시지 publish
+        redisTemplate.convertAndSend(channelTopic.getTopic(), message);
+    }
+    
+    public void saveMessage(ChatMessage message) {
+        String key = "chat:room:" + message.roomId();
+        redisTemplate.opsForList().rightPush(key, message);
+        log.debug("메시지 저장 - 방: {}, 발신자: {}", message.roomId(), message.senderNickname());
+    }
+} 


### PR DESCRIPTION
## 요약
Redis Pub/Sub 구조를 적용하여 채팅 메시지를 전송하는 로직을 개선함.
기존 ChatController에서 직접 SimpMessagingTemplate을 호출하던 구조를 Service 계층 → Redis 발행 → Subscriber 수신으로 변경하여 구조적 분리/
<br><br>

## 작업 내용
- ChatController에서 메시지 발송 로직 제거, ChatService.sendMessage() 호출로 위임
- ChatService에서 메시지를 Redis에 저장 및 convertAndSend
- RedisMessageSubscriber에서 Redis 구독 메시지를 수신 후, 클라이언트로 전송
- RedisTemplate value serializer 설정 (Jackson2JsonRedisSerializer)
- 테스트용 HTML에서도 정상 작동 확인
<br><br>

## 참고 사항
채팅 저장(key: chat:room:{roomId})은 Redis List 구조 사용, 추후 삭제/조회 기능 추가해야함.

<br><br>

## 관련 이슈

- Close #45 

<br><br>
