### PR TITLE
feat: 사용자 정보 관리 기능 구현 (조회/수정, 비밀번호 변경, 탈퇴 등)

### DIFF
--- a/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,8 @@ import com.swu.room.exception.AlreadyJoinedRoomException;
 import com.swu.room.exception.NotJoinedRoomException;
 import com.swu.room.exception.RoomFullException;
 import com.swu.room.exception.RoomNotFoundException;
+import com.swu.user.exception.UserNotFoundException;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -62,6 +64,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserNotFoundException(UserNotFoundException e) {
+        log.warn("UserNotFoundException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(HttpStatus.NOT_FOUND, e.getMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,9 @@ import com.swu.room.exception.AlreadyJoinedRoomException;
 import com.swu.room.exception.NotJoinedRoomException;
 import com.swu.room.exception.RoomFullException;
 import com.swu.room.exception.RoomNotFoundException;
+import com.swu.user.exception.EmailAlreadyExistsException;
+import com.swu.user.exception.InvalidCurrentPasswordException;
+import com.swu.user.exception.PasswordRedundancyException;
 import com.swu.user.exception.UserNotFoundException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +75,30 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.error(HttpStatus.NOT_FOUND, e.getMessage()));
+    }
+
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    public ResponseEntity<ApiResponse<Void>> handleEmailAlreadyExistsException(EmailAlreadyExistsException e) {
+        log.warn("EmailAlreadyExistsException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidCurrentPasswordException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidCurrentPasswordException(InvalidCurrentPasswordException e) {
+        log.warn("InvalidCurrentPasswordException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
+    }
+
+    @ExceptionHandler(PasswordRedundancyException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePasswordRedundancyException(PasswordRedundancyException e) {
+        log.warn("PasswordRedundancyException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(HttpStatus.CONFLICT, e.getMessage()));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/backend/src/main/java/com/swu/user/controller/UserController.java
+++ b/backend/src/main/java/com/swu/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.swu.user.controller;
 import com.swu.auth.domain.CustomUserDetails;
 import com.swu.global.response.ApiResponse;
 import com.swu.user.domain.User;
+import com.swu.user.dto.request.PasswordChangeRequest;
 import com.swu.user.dto.request.SignupRequest;
 import com.swu.user.dto.request.UserUpdateRequests;
 import com.swu.user.dto.response.UserInfoResponse;
@@ -35,7 +36,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.ok("내 정보 조회 성공", response));
     }
 
-    @Operation(summary = "내 닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
+    @Operation(summary = "닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
     @PatchMapping("/users/me/nickname")
     public ResponseEntity<ApiResponse<Void>> updateNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -45,7 +46,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.ok("닉네임 변경 성공", null));
     }
 
-    @Operation(summary = "내 닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
+    @Operation(summary = "프로필 이미지 수정", description = "현재 로그인한 사용자의 프로필을 수정합니다.")
     @PatchMapping("/users/me/profileImg")
     public ResponseEntity<ApiResponse<Void>> updateProfileImg(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -53,5 +54,23 @@ public class UserController {
         User user = userDetails.getUser();
         userService.updateProfileImg(user.getId(), request.getProfileImg());
         return ResponseEntity.ok(ApiResponse.ok("프로필 이미지 변경 성공", null));
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "현재 로그인한 사용자의 비밀번호를 변경합니다.")
+    @PatchMapping("/users/me/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid PasswordChangeRequest request) {
+        User user = userDetails.getUser();
+        userService.updatePassword(user.getId(), request.getCurrentPassword(), request.getNewPassword());
+        return ResponseEntity.ok(ApiResponse.ok("비밀번호 변경 성공", null));
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다.")
+    @DeleteMapping("/users/me")
+    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        User user = userDetails.getUser();
+        userService.deleteUser(user.getId());
+        return ResponseEntity.ok(ApiResponse.ok("회원 탈퇴 성공", null));
     }
 }

--- a/backend/src/main/java/com/swu/user/controller/UserController.java
+++ b/backend/src/main/java/com/swu/user/controller/UserController.java
@@ -1,12 +1,17 @@
 package com.swu.user.controller;
 
+import com.swu.auth.domain.CustomUserDetails;
 import com.swu.global.response.ApiResponse;
+import com.swu.user.domain.User;
 import com.swu.user.dto.request.SignupRequest;
+import com.swu.user.dto.request.UserUpdateRequests;
+import com.swu.user.dto.response.UserInfoResponse;
 import com.swu.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,5 +25,33 @@ public class UserController {
     public ResponseEntity<ApiResponse<Void>> signup(@RequestBody @Valid SignupRequest request) {
         userService.signup(request);
         return ResponseEntity.ok(ApiResponse.ok("회원가입 성공", null));
+    }
+
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
+    @GetMapping("/users/me")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        User user = userDetails.getUser();
+        UserInfoResponse response = userService.getUserInfo(user.getId());
+        return ResponseEntity.ok(ApiResponse.ok("내 정보 조회 성공", response));
+    }
+
+    @Operation(summary = "내 닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
+    @PatchMapping("/users/me/nickname")
+    public ResponseEntity<ApiResponse<Void>> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UserUpdateRequests.Nickname request) {
+        User user = userDetails.getUser();
+        userService.updateNickname(user.getId(), request.getNickname());
+        return ResponseEntity.ok(ApiResponse.ok("닉네임 변경 성공", null));
+    }
+
+    @Operation(summary = "내 닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
+    @PatchMapping("/users/me/profileImg")
+    public ResponseEntity<ApiResponse<Void>> updateProfileImg(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UserUpdateRequests.ProfileImg request) {
+        User user = userDetails.getUser();
+        userService.updateProfileImg(user.getId(), request.getProfileImg());
+        return ResponseEntity.ok(ApiResponse.ok("프로필 이미지 변경 성공", null));
     }
 }

--- a/backend/src/main/java/com/swu/user/domain/User.java
+++ b/backend/src/main/java/com/swu/user/domain/User.java
@@ -43,4 +43,12 @@ public class User {
 
     @CreationTimestamp
     private Timestamp createdAt;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImg(String profileImg) {
+        this.profileImg = profileImg;
+    }
 }

--- a/backend/src/main/java/com/swu/user/domain/User.java
+++ b/backend/src/main/java/com/swu/user/domain/User.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.sql.Timestamp;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -26,17 +27,20 @@ public class User {
     @Column(nullable = false, length = 30)
     private String nickname;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private Role role;
+    private Role role = Role.USER;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private LoginType loginType;
+    private LoginType loginType = LoginType.LOCAL;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private Grade grade;
+    private Grade grade = Grade.BRONZE;
 
     @Column(nullable = true, length = 255)
     private String profileImg;
@@ -44,11 +48,27 @@ public class User {
     @CreationTimestamp
     private Timestamp createdAt;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
 
     public void updateProfileImg(String profileImg) {
         this.profileImg = profileImg;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    public void withdraw() {
+        this.isDeleted = true;
+        this.email = "deleted_" + UUID.randomUUID() + "@deleted.com";
+        this.password = null;
+        this.nickname = "탈퇴한 사용자";
+        this.profileImg = null;
     }
 }

--- a/backend/src/main/java/com/swu/user/dto/request/PasswordChangeRequest.java
+++ b/backend/src/main/java/com/swu/user/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,15 @@
+package com.swu.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordChangeRequest {
+    @NotBlank(message = "현재 비밀번호는 필수 입력 항목입니다.")
+    private String currentPassword;
+
+    @NotBlank(message = "새로운 비밀번호는 필수 입력 항목입니다.")
+    private String newPassword;
+}

--- a/backend/src/main/java/com/swu/user/dto/request/UserUpdateRequests.java
+++ b/backend/src/main/java/com/swu/user/dto/request/UserUpdateRequests.java
@@ -1,0 +1,22 @@
+package com.swu.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserUpdateRequests {
+    
+    @Getter
+    @NoArgsConstructor
+    public static class Nickname {
+        @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+        private String nickname;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ProfileImg {
+        @NotBlank(message = "프로필 이미지는 필수 입력 항목입니다.")
+        private String profileImg;
+    }
+}

--- a/backend/src/main/java/com/swu/user/dto/response/UserInfoResponse.java
+++ b/backend/src/main/java/com/swu/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,20 @@
+package com.swu.user.dto.response;
+
+import com.swu.user.domain.Grade;
+import com.swu.user.domain.LoginType;
+import com.swu.user.domain.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoResponse {
+    private Long id;
+    private String email;
+    private String nickname;
+    private Role role;
+    private LoginType loginType;
+    private Grade grade;
+    private String profileImg;
+    private String createdAt;
+} 

--- a/backend/src/main/java/com/swu/user/exception/EmailAlreadyExistsException.java
+++ b/backend/src/main/java/com/swu/user/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.swu.user.exception;
+
+public class EmailAlreadyExistsException extends RuntimeException {
+    public EmailAlreadyExistsException() {
+        super("이미 사용 중인 이메일입니다.");
+    }
+}

--- a/backend/src/main/java/com/swu/user/exception/InvalidCurrentPasswordException.java
+++ b/backend/src/main/java/com/swu/user/exception/InvalidCurrentPasswordException.java
@@ -1,0 +1,7 @@
+package com.swu.user.exception;
+
+public class InvalidCurrentPasswordException extends RuntimeException {
+    public InvalidCurrentPasswordException() {
+        super("현재 비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/backend/src/main/java/com/swu/user/exception/PasswordRedundancyException.java
+++ b/backend/src/main/java/com/swu/user/exception/PasswordRedundancyException.java
@@ -1,0 +1,7 @@
+package com.swu.user.exception;
+
+public class PasswordRedundancyException extends RuntimeException {
+    public PasswordRedundancyException() {
+        super("새 비밀번호는 기존 비밀번호와 달라야 합니다.");
+    }
+}

--- a/backend/src/main/java/com/swu/user/exception/UserNotFoundException.java
+++ b/backend/src/main/java/com/swu/user/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.swu.user.exception;
+
+public class UserNotFoundException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 사용자입니다.";
+
+    public UserNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/swu/user/service/UserService.java
+++ b/backend/src/main/java/com/swu/user/service/UserService.java
@@ -5,6 +5,8 @@ import com.swu.user.domain.LoginType;
 import com.swu.user.domain.Role;
 import com.swu.user.domain.User;
 import com.swu.user.dto.request.SignupRequest;
+import com.swu.user.dto.response.UserInfoResponse;
+import com.swu.user.exception.UserNotFoundException;
 import com.swu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -37,5 +39,38 @@ public class UserService {
                 .build();
 
         userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public UserInfoResponse getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException());
+
+        return UserInfoResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .loginType(user.getLoginType())
+                .grade(user.getGrade())
+                .profileImg(user.getProfileImg())
+                .createdAt(user.getCreatedAt().toString())
+                .build();
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, String nickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException());
+
+        user.updateNickname(nickname);
+    }
+
+    @Transactional
+    public void updateProfileImg(Long userId, String profileImg) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException());
+
+        user.updateProfileImg(profileImg);
     }
 }


### PR DESCRIPTION
## 요약
사용자 도메인에 대한 핵심 기능을 구현.
내 정보 조회, 닉네임 및 프로필 수정, 비밀번호 변경, 회원 탈퇴 등 전반적인 사용자 관리 API를 포함.

<br><br>

## 작업 내용
- 내 정보 조회 API 구현 (`/users/me`)
- 닉네임 변경 API (`/users/me/nickname`)
- 프로필 이미지 변경 API (`/users/me/profileImg`)
- 비밀번호 변경 API (`/users/me/password`)
  - 현재 비밀번호 일치 여부 검증
  - 기존 비밀번호 재사용 제한
- 회원 탈퇴 API (`/users/me`)
  - soft delete 처리 + 개인정보 비식별화
- 관련 커스텀 예외 클래스 정의
  - `UserNotFoundException`
  - `EmailAlreadyExistsException`
  - `InvalidCurrentPasswordException`
  - `PasswordRedundancyException`
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #51 

<br><br>
