### PR TITLE
feat: 일기 생성 및 조회 기능 구현 및 날짜 직렬화 설정 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	// Validation API
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// Jackson
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.4'
+
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/backend/src/main/java/com/swu/diary/controller/DiaryController.java
+++ b/backend/src/main/java/com/swu/diary/controller/DiaryController.java
@@ -1,0 +1,68 @@
+package com.swu.diary.controller;
+
+import java.time.YearMonth;
+import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.swu.auth.domain.CustomUserDetails;
+import com.swu.diary.dto.request.DiaryRequest;
+import com.swu.diary.dto.response.DiaryResponse;
+import com.swu.diary.dto.response.DiarySummaryResponse;
+import com.swu.diary.service.DiaryService;
+import com.swu.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/diaries")
+@RequiredArgsConstructor
+@Tag(name = "Diary", description = "일기 관련 API")
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @PostMapping
+    @Operation(summary = "일기 생성", description = "일기를 새로 생성합니다.")
+    public ResponseEntity<ApiResponse<Void>> createDiary(
+        @RequestBody @Valid DiaryRequest request,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        diaryService.createDiary(userDetails.getUser().getId(), request);
+
+        return ResponseEntity.ok(ApiResponse.ok("일기 생성 성공", null));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "일기 단건 조회", description = "id를 이용해 사용자의 일기를 조회합니다.")
+    public ResponseEntity<ApiResponse<DiaryResponse>> getDiary(
+        @PathVariable Long id,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        DiaryResponse response = diaryService.getDiary(id, userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.ok("일기 조회 성공", response));
+    }
+
+    @GetMapping
+    @Operation(summary = "일기 목록 조회", description = "선택된 월에 해당하는 사용자의 일기 목록을 조회합니다. 월을 지정하지 않으면 전체 조회됩니다.")
+    public ResponseEntity<ApiResponse<List<DiarySummaryResponse>>> getDiaries(
+        @RequestParam(required = false)
+        @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        List<DiarySummaryResponse> response = diaryService.getDiaries(userDetails.getUser().getId(), month);
+        return ResponseEntity.ok(ApiResponse.ok("일기 목록 조회 성공", response));
+    }
+}

--- a/backend/src/main/java/com/swu/diary/domain/Diary.java
+++ b/backend/src/main/java/com/swu/diary/domain/Diary.java
@@ -36,15 +36,12 @@ public class Diary {
     @JoinColumn(name = "user_id")
     private User user;
 
-    // 하루에 한 번 작성
     @Column(name = "diary_date", nullable = false)
     private LocalDate diaryDate;
 
-    // 생성 시점 자동 저장
     @CreationTimestamp
     private LocalDateTime createdAt;
 
-    // 챗봇 피드백 (선택사항)
     @Lob
     private String feedback;
 }

--- a/backend/src/main/java/com/swu/diary/dto/request/DiaryRequest.java
+++ b/backend/src/main/java/com/swu/diary/dto/request/DiaryRequest.java
@@ -1,0 +1,12 @@
+package com.swu.diary.dto.request;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DiaryRequest(
+    @NotBlank String title,
+    @NotBlank String content,
+    @NotNull LocalDate diaryDate
+) {}

--- a/backend/src/main/java/com/swu/diary/dto/response/DiaryResponse.java
+++ b/backend/src/main/java/com/swu/diary/dto/response/DiaryResponse.java
@@ -1,0 +1,26 @@
+package com.swu.diary.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.swu.diary.domain.Diary;
+
+public record DiaryResponse(
+    Long id,
+    String title,
+    String content,
+    LocalDate diaryDate,
+    LocalDateTime createdAt,
+    String feedback
+) {
+    public static DiaryResponse from(Diary diary) {
+        return new DiaryResponse(
+            diary.getId(),
+            diary.getTitle(),
+            diary.getContent(),
+            diary.getDiaryDate(),
+            diary.getCreatedAt(),
+            diary.getFeedback()
+        );
+    }
+}

--- a/backend/src/main/java/com/swu/diary/dto/response/DiarySummaryResponse.java
+++ b/backend/src/main/java/com/swu/diary/dto/response/DiarySummaryResponse.java
@@ -1,0 +1,22 @@
+package com.swu.diary.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.swu.diary.domain.Diary;
+
+public record DiarySummaryResponse(
+    Long id,
+    String title,
+    LocalDate diaryDate,
+    LocalDateTime createdAt
+) {
+    public static DiarySummaryResponse from(Diary diary) {
+        return new DiarySummaryResponse(
+            diary.getId(),
+            diary.getTitle(),
+            diary.getDiaryDate(),
+            diary.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/swu/diary/exception/DiaryAlreadyExistsException.java
+++ b/backend/src/main/java/com/swu/diary/exception/DiaryAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.swu.diary.exception;
+
+public class DiaryAlreadyExistsException extends RuntimeException {
+    public DiaryAlreadyExistsException() {
+        super("해당 날짜에 이미 작성된 일기가 있습니다.");
+    }
+}

--- a/backend/src/main/java/com/swu/diary/exception/DiaryNotFoundException.java
+++ b/backend/src/main/java/com/swu/diary/exception/DiaryNotFoundException.java
@@ -1,0 +1,7 @@
+package com.swu.diary.exception;
+
+public class DiaryNotFoundException extends RuntimeException {
+    public DiaryNotFoundException() {
+        super("일기를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/swu/diary/repository/DiaryRepository.java
+++ b/backend/src/main/java/com/swu/diary/repository/DiaryRepository.java
@@ -3,5 +3,13 @@ package com.swu.diary.repository;
 import com.swu.diary.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    boolean existsByUserIdAndDiaryDate(Long userId, LocalDate diaryDate);
+    Optional<Diary> findByIdAndUserId(Long id, Long userId);
+    List<Diary> findByUserIdOrderByDiaryDateDesc(Long userId);
+    List<Diary> findByUserIdAndDiaryDateBetweenOrderByDiaryDateDesc(Long userId, LocalDate start, LocalDate end);
 }

--- a/backend/src/main/java/com/swu/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/swu/diary/service/DiaryService.java
@@ -1,0 +1,77 @@
+package com.swu.diary.service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.swu.diary.domain.Diary;
+import com.swu.diary.dto.request.DiaryRequest;
+import com.swu.diary.dto.response.DiaryResponse;
+import com.swu.diary.dto.response.DiarySummaryResponse;
+import com.swu.diary.exception.DiaryAlreadyExistsException;
+import com.swu.diary.exception.DiaryNotFoundException;
+import com.swu.diary.repository.DiaryRepository;
+import com.swu.user.domain.User;
+import com.swu.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+
+    private final UserRepository userRepository;
+    private final DiaryRepository diaryRepository;
+
+    @Transactional
+    public void createDiary(Long userId, DiaryRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalStateException("인증된 유저가 DB에 존재하지 않음"));
+
+        boolean isExist = diaryRepository.existsByUserIdAndDiaryDate(userId, request.diaryDate());
+        
+        if (isExist) {
+            throw new DiaryAlreadyExistsException();
+        }
+
+        String dummyFeedBack = "오늘 하루 힘든 일이 있었지만, 그래도 회고를 쓴 당신은 멋집니다.";
+
+        Diary diary = Diary.builder()
+            .user(user)
+            .title(request.title())
+            .content(request.content())
+            .diaryDate(request.diaryDate())
+            .feedback(dummyFeedBack)
+            .build();
+
+        diaryRepository.save(diary);
+    }
+
+    @Transactional(readOnly = true)
+    public DiaryResponse getDiary(Long id, Long userId) {
+        Diary diary = diaryRepository.findByIdAndUserId(id, userId)
+            .orElseThrow(() -> new DiaryNotFoundException());
+
+        return DiaryResponse.from(diary);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DiarySummaryResponse> getDiaries(Long userId, YearMonth month) {
+        List<Diary> diaries;
+
+        if (month != null) {
+            LocalDate start = month.atDay(1);
+            LocalDate end = month.atEndOfMonth();
+            diaries = diaryRepository.findByUserIdAndDiaryDateBetweenOrderByDiaryDateDesc(userId, start, end);
+        } else {
+            diaries = diaryRepository.findByUserIdOrderByDiaryDateDesc(userId);
+        }
+
+        return diaries.stream()
+            .map(DiarySummaryResponse::from)
+            .toList();
+    }
+}

--- a/backend/src/main/java/com/swu/global/config/JacksonConfig.java
+++ b/backend/src/main/java/com/swu/global/config/JacksonConfig.java
@@ -1,0 +1,24 @@
+package com.swu.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+    
+        // Java 8 날짜/시간 타입(LocalDate, LocalDateTime 등) 지원을 위한 모듈 등록
+        mapper.registerModule(new JavaTimeModule());
+        // 날짜를 timestamp 배열([2025,4,20])이 아닌 ISO-8601 문자열("2025-04-20")로 직렬화하도록 설정
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        
+        return mapper;
+    }
+}

--- a/backend/src/main/java/com/swu/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/swu/global/config/RedisConfig.java
@@ -11,7 +11,6 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
  import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swu.room.listener.RedisMessageSubscriber;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -33,10 +32,6 @@ public class RedisConfig {
     @Value("${spring.data.redis.password}")
     private String password;
 
-    @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper();
-    }
     /**
      * Redis 연결 팩토리 빈 등록
      * - Lettuce 클라이언트를 사용하여 Redis에 연결함


### PR DESCRIPTION
## 요약
일기 작성 및 조회 기능을 위한 전체적인 백엔드 구현을 완료하고, 날짜 관련 직렬화/역직렬화 문제 해결 및 API 문서화를 적용
<br><br>

## 작업 내용
- 일기 생성 및 조회 기능  개발
  - POST /api/diaries: 일기 생성
  - GET /api/diaries/{id}: 특정 일기 단건 조회
  - GET /api/diaries?month=2025-04: 특정 월의 일기 목록 조회
- DTO 클래스 작성
  - DiaryRequest: 일기 생성 요청 DTO
  - DiaryResponse: 단건 조회 응답 DTO
  - DiarySummaryResponse: 목록 조회 응답 DTO (내용 생략+요약 응답용)
- 직렬화/역직렬화 설정
  - JacksonConfig에서 JavaTimeModule 등록
  - LocalDate, LocalDateTime을 문자열(ISO-8061 포맷)로 처리하도록 설정
- 예외 처리
  - 날짜 형식 잘못된 경우(yyyy-MM-dd 형식이 아님), HttpMessageNotReadableException을 분기처리하여 명확한 에러 메시지 제공
  - 일기가 중복되거나 존재하지 않을 경우 커스텀 예외 처리
    - DiaryAlreadyExistsException
    - DiaryNotFoundException
- Swagger 문서화 어노테이션 추가
- Postman으로 테스트 완료
<br><br>

## 참고 사항
- RedisConfig에서 ObjectMapper 관련 설정은 제거하고, Jackson 설정을 JacksonConfig로 통합
- 조회 시 LocalDate 필드가 JSON 직렬화되지 않아 발생하던 오류는 jackson-datatype-jsr310 의존성과 커스텀 설정으로 해결됨
(LocalDate 역직렬화 이슈도 위 의존성 + ObjectMapper에 포맷 추가로써 해결됨)

<br><br>

## 관련 이슈

- Close #55 

<br><br>
