### PR TITLE
refactor: 모든 API /api prefix 통일 작업

### DIFF
--- a/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
@@ -34,7 +34,7 @@ public class JWTFilter extends OncePerRequestFilter{
             throws ServletException, IOException {
         String path = request.getRequestURI();
 
-        if (path.startsWith("/auth")
+        if (path.startsWith("/api/auth")
                 || path.startsWith("/ws")
                 || path.startsWith("/v3/api-docs")
                 || path.startsWith("/swagger-ui")) {

--- a/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
@@ -42,7 +42,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter{
         this.authenticationManager = authenticationManager;
         this.jwtUtil = jwtUtil;
 
-        setFilterProcessesUrl("/auth/login");
+        setFilterProcessesUrl("/api/auth/login");
     }
 
     // 로그인 요청을 처리하는 메소드

--- a/backend/src/main/java/com/swu/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/swu/global/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/ws/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/ws/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/backend/src/main/java/com/swu/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/swu/global/config/WebSocketConfig.java
@@ -35,5 +35,5 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompJwtInterceptor); 
-}
+    }
 }

--- a/backend/src/main/java/com/swu/room/controller/RoomController.java
+++ b/backend/src/main/java/com/swu/room/controller/RoomController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/room")
+@RequestMapping("/api/rooms")
 @RequiredArgsConstructor
 public class RoomController {
 

--- a/backend/src/main/java/com/swu/room/controller/RoomMemberController.java
+++ b/backend/src/main/java/com/swu/room/controller/RoomMemberController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/room")
+@RequestMapping("/api/rooms")
 @RequiredArgsConstructor
 public class RoomMemberController {
 

--- a/backend/src/main/java/com/swu/user/controller/UserController.java
+++ b/backend/src/main/java/com/swu/user/controller/UserController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/frontend/src/pages/login/Login.js
+++ b/frontend/src/pages/login/Login.js
@@ -19,7 +19,7 @@ function Login() {
     }
 
     try {
-      const res = await fetch("http://localhost:8080/auth/login", {
+      const res = await fetch("http://localhost:8080/api/auth/login", {
         method: "POST", //데이터를 서버에 전달할때 사용용
         headers: {
           "Content-Type": "application/json", //json형식으로

--- a/frontend/src/pages/sighup/Signup.js
+++ b/frontend/src/pages/sighup/Signup.js
@@ -32,7 +32,7 @@ function Signup() {
     }
 
     try {
-      const res = await fetch("http://localhost:8080/auth/signup", {
+      const res = await fetch("http://localhost:8080/api/auth/signup", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## 요약
API 경로 통일을 위해 백엔드 및 프론트의 모든 API 요청 경로에 `/api` prefix를 적용.

<br><br>

## 작업 내용
- 모든 @RequestMapping 및 @GetMapping 등에 `/api` prefix 추가
- Spring Security 예외 경로 수정 (`/api/auth/**`, `/api/ws/**` 등)
- 프론트 API 호출 경로 axios 요청 경로 일괄 수정
- Swagger, WebSocket, 정적 자원 경로는 기존대로 유지
- 개발 및 배포 환경에서 nginx 프록시 경로와의 일관성 확보

<br><br>

## 참고 사항
- 추후 추가 API도 `/api` prefix 준수 필요
<br><br>

## 관련 이슈

- Close #XXX

<br><br>
