### PR TITLE
fix: GHCR 태그명 오류 수정

### DIFF
--- a/.github/workflows/build-ghcr.yml
+++ b/.github/workflows/build-ghcr.yml
@@ -31,10 +31,10 @@ jobs:
 
       - name: Build and Push Backend Docker Image
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/backend:latest ./backend
-          docker push ghcr.io/${{ github.repository_owner }}/backend:latest
+          docker build -t ghcr.io/swu-team/backend:latest ./backend
+          docker push ghcr.io/swu-team/backend:latest
 
       - name: Build and Push Frontend Docker Image
         run: |
-          docker build -t ghcr.io/${{ github.repository_owner }}/frontend:latest ./frontend
-          docker push ghcr.io/${{ github.repository_owner }}/frontend:latest
+          docker build -t ghcr.io/swu-team/frontend:latest ./frontend
+          docker push ghcr.io/swu-team/frontend:latest


### PR DESCRIPTION
## 요약
GHCR 태그명 오류 수정

<br><br>

## 작업 내용
GitHub Actions 워크플로우 파일 (build-ghcr.yml)에서
자동 푸시되는 GHCR 이미지 경로를 swu-team으로 고정

기존 ${{ github.repository_owner }} 사용 시 발생하던 대문자 포함 오류 해결
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #XXX

<br><br>
