### PR TITLE
feat: 환경별 API 주소 분리를 위한 .env 설정 추가

### DIFF
--- a/frontend/src/pages/login/Login.js
+++ b/frontend/src/pages/login/Login.js
@@ -19,7 +19,8 @@ function Login() {
     }
 
     try {
-      const res = await fetch("http://localhost:8080/api/auth/login", {
+      console.log("ENV:", process.env.REACT_APP_API_BASE_URL);
+      const res = await fetch(`${process.env.REACT_APP_API_BASE_URL}/auth/login`, {
         method: "POST", //데이터를 서버에 전달할때 사용용
         headers: {
           "Content-Type": "application/json", //json형식으로

--- a/frontend/src/pages/sighup/Signup.js
+++ b/frontend/src/pages/sighup/Signup.js
@@ -32,7 +32,7 @@ function Signup() {
     }
 
     try {
-      const res = await fetch("http://localhost:8080/api/auth/signup", {
+      const res = await fetch(`${process.env.REACT_APP_API_BASE_URL}/auth/signup`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## 요약
REST API 요청의 base URL을 `.env`로 분리하여 관리할 수 있도록 개선함.  
기존 로그인/회원가입 요청에 해당 방식 적용 완료.

<br><br>

## 작업 내용
- Axios 요청 경로를 `.env`에서 가져오도록 변경
- `.env.development`, `.env.production` 파일 생성
- 현재 구현된 로그인, 회원가입 요청 로직에 적용
- 불필요한 하드코딩 URL 제거
<br><br>

## 참고 사항
- `.env.*` 파일은 `.gitignore`에 등록되어 있어 커밋 X 
- 실제 운영 배포 시에는 `.env.production`의 값을 알맞게 설정해야 함

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>
