### PR TITLE
feat: 전역 폰트 설정, 스터디름 목록 API 연동 및 UI 리팩토링

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,7 +11,7 @@ import Diary from "./pages/diary/Diary";
 import Planer from "./pages/planer/Planer";
 import StudyRoomList from "./pages/rooms/StudyRoomList";
 import Startpage from "./pages/startpage/Startpage";
-import StudyRoom from "./pages/rooms/StudyRoom";
+// import StudyRoom from "./pages/rooms/StudyRoom";
 import { isAuthenticated } from "./utils/auth";
 
 // 인증이 필요한 페이지들을 감싸는 컴포넌트
@@ -39,7 +39,7 @@ function App() {
           <Route path="/diary" element={<Diary />} />
           <Route path="/planer" element={<Planer />} />
           <Route path="/rooms" element={<StudyRoomList />} />
-          <Route path="/rooms/:roomId" element={<StudyRoom />} />
+          {/* <Route path="/rooms/:roomId" element={<StudyRoom />} /> */}
         </Route>
 
         {/* 404 페이지 */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,23 @@
 /* index.css */
-html, body, #root {
-    margin: 0;
-    padding: 0;
-    width: 100vw;
-    height: 100vh;
-    box-sizing: border-box;
-  }
-  
-  *, *::before, *::after {
-    box-sizing: inherit;
-  }
-  
+
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
+
+body {
+  font-family: "Pretendard", sans-serif;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  width: 100vw;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,7 +1,7 @@
+import "./index.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import "./index.css";
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>

--- a/frontend/src/pages/mypage/Mypage.js
+++ b/frontend/src/pages/mypage/Mypage.js
@@ -98,149 +98,147 @@ function Mypage() {
   });
 
   return (
-    <Layout>
-      <div className={styles.wrapper}>
-        <h2 className={styles.title}>마이페이지</h2>
+    <div className={styles.wrapper}>
+      <h2 className={styles.title}>마이페이지</h2>
 
-        {/* 프로필 */}
-        <div className={`${styles.section} ${styles.profileSection}`}>
-          <img
-            src={profileImage}
-            alt="Profile"
-            className={styles.profileImage}
-          />
-          <div className={styles.profileInfo}>
-            <h3>{nickname}</h3>
-            <p>{email}</p>
-          </div>
+      {/* 프로필 */}
+      <div className={`${styles.section} ${styles.profileSection}`}>
+        <img
+          src={profileImage}
+          alt="Profile"
+          className={styles.profileImage}
+        />
+        <div className={styles.profileInfo}>
+          <h3>{nickname}</h3>
+          <p>{email}</p>
+        </div>
+        <button
+          className={styles.editButton}
+          onClick={() => setShowEditModal(true)}
+        >
+          수정
+        </button>
+      </div>
+
+      {/* 📌 스터디 랭킹 */}
+      <div className={styles.section}>
+        <h3>스터디 랭킹</h3>
+        <div className={styles.rankButtons}>
           <button
-            className={styles.editButton}
-            onClick={() => setShowEditModal(true)}
+            className={rankMode === "daily" ? styles.activeBtn : ""}
+            onClick={() => setRankMode("daily")}
           >
-            수정
+            일간
+          </button>
+          <button
+            className={rankMode === "monthly" ? styles.activeBtn : ""}
+            onClick={() => setRankMode("monthly")}
+          >
+            월간
           </button>
         </div>
-
-        {/* 📌 스터디 랭킹 */}
-        <div className={styles.section}>
-          <h3>스터디 랭킹</h3>
-          <div className={styles.rankButtons}>
-            <button
-              className={rankMode === "daily" ? styles.activeBtn : ""}
-              onClick={() => setRankMode("daily")}
-            >
-              일간
-            </button>
-            <button
-              className={rankMode === "monthly" ? styles.activeBtn : ""}
-              onClick={() => setRankMode("monthly")}
-            >
-              월간
-            </button>
+        {sortedRanking.map((friend, index) => (
+          <div key={friend.id} className={styles.rankItem}>
+            <span className={styles.rankNum}>{index + 1}위</span>
+            <span className={styles.rankName}>{friend.name}</span>
+            <span className={styles.rankHours}>
+              {rankMode === "daily"
+                ? `${friend.dailyHours}시간`
+                : `${friend.monthlyHours}시간`}
+            </span>
           </div>
-          {sortedRanking.map((friend, index) => (
-            <div key={friend.id} className={styles.rankItem}>
-              <span className={styles.rankNum}>{index + 1}위</span>
-              <span className={styles.rankName}>{friend.name}</span>
-              <span className={styles.rankHours}>
-                {rankMode === "daily"
-                  ? `${friend.dailyHours}시간`
-                  : `${friend.monthlyHours}시간`}
-              </span>
+        ))}
+      </div>
+
+      {/* 친구 */}
+      <div className={styles.friendSection}>
+        <h4>친구</h4>
+        <input
+          type="text"
+          placeholder="친구 검색"
+          className={styles.inputField}
+        />
+        <div className={styles.friendList}>
+          {dummyFriends.map((friend) => (
+            <div key={friend.id} className={styles.friendItem}>
+              <img
+                src={friend.image}
+                alt="profile"
+                className={styles.friendAvatar}
+              />
+              <div className={styles.friendInfo}>
+                <strong>{friend.name}</strong>
+                <p>{friend.status}</p>
+              </div>
             </div>
           ))}
         </div>
+      </div>
 
-        {/* 친구 */}
-        <div className={styles.friendSection}>
-          <h4>친구</h4>
-          <input
-            type="text"
-            placeholder="친구 검색"
-            className={styles.inputField}
-          />
-          <div className={styles.friendList}>
-            {dummyFriends.map((friend) => (
-              <div key={friend.id} className={styles.friendItem}>
-                <img
-                  src={friend.image}
-                  alt="profile"
-                  className={styles.friendAvatar}
-                />
-                <div className={styles.friendInfo}>
-                  <strong>{friend.name}</strong>
-                  <p>{friend.status}</p>
-                </div>
-              </div>
-            ))}
-          </div>
+      {/* 하단 일간/월간 공부 시간 */}
+      <div className={styles.subGrid}>
+        <div className={styles.subSection}>
+          <h4>일별 공부시간</h4>
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={dailyStudyData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="day" />
+              <YAxis unit="시간" />
+              <Tooltip />
+              <Bar dataKey="hours" fill="#82ca9d" radius={[5, 5, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
         </div>
-
-        {/* 하단 일간/월간 공부 시간 */}
-        <div className={styles.subGrid}>
-          <div className={styles.subSection}>
-            <h4>일별 공부시간</h4>
-            <ResponsiveContainer width="100%" height={180}>
-              <BarChart data={dailyStudyData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="day" />
-                <YAxis unit="시간" />
-                <Tooltip />
-                <Bar dataKey="hours" fill="#82ca9d" radius={[5, 5, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-          <div className={styles.subSection}>
-            <h4>월별 공부시간</h4>
-            <ResponsiveContainer width="100%" height={180}>
-              <BarChart data={monthlyStudyData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="month" />
-                <YAxis unit="시간" />
-                <Tooltip />
-                <Bar dataKey="hours" fill="#8884d8" radius={[5, 5, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
+        <div className={styles.subSection}>
+          <h4>월별 공부시간</h4>
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={monthlyStudyData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" />
+              <YAxis unit="시간" />
+              <Tooltip />
+              <Bar dataKey="hours" fill="#8884d8" radius={[5, 5, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
         </div>
+      </div>
 
-        {/* 수정 모달 */}
-        {showEditModal && (
-          <div className={styles.modalOverlay}>
-            <div className={styles.modal}>
-              <h3>프로필 수정</h3>
-              <input
-                type="text"
-                placeholder="새 닉네임"
-                value={newNickname}
-                onChange={(e) => setNewNickname(e.target.value)}
-                className={styles.inputField}
-              />
-              <input
-                type="file"
-                accept="image/*"
-                onChange={handleImageChange}
-                className={styles.inputField}
-              />
-              <div className={styles.modalButtons}>
-                <button
-                  onClick={handleSaveProfile}
-                  className={styles.submitBtn}
-                >
-                  저장
-                </button>
-                <button
-                  onClick={() => setShowEditModal(false)}
-                  className={styles.cancelBtn}
-                >
-                  취소
-                </button>
-              </div>
+      {/* 수정 모달 */}
+      {showEditModal && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modal}>
+            <h3>프로필 수정</h3>
+            <input
+              type="text"
+              placeholder="새 닉네임"
+              value={newNickname}
+              onChange={(e) => setNewNickname(e.target.value)}
+              className={styles.inputField}
+            />
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleImageChange}
+              className={styles.inputField}
+            />
+            <div className={styles.modalButtons}>
+              <button
+                onClick={handleSaveProfile}
+                className={styles.submitBtn}
+              >
+                저장
+              </button>
+              <button
+                onClick={() => setShowEditModal(false)}
+                className={styles.cancelBtn}
+              >
+                취소
+              </button>
             </div>
           </div>
-        )}
-      </div>
-    </Layout>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/pages/mypage/Mypage.module.css
+++ b/frontend/src/pages/mypage/Mypage.module.css
@@ -1,7 +1,7 @@
 .wrapper {
-  padding: 40px;
-  background-color: #f9f9f9;
-  min-height: 100vh;
+  padding: 20px;
+  width: 100%;
+  height: 100%;
   display: grid;
   grid-template-columns: 1fr 2fr 1fr;
   gap: 20px;

--- a/frontend/src/pages/rooms/StudyRoomList.js
+++ b/frontend/src/pages/rooms/StudyRoomList.js
@@ -1,17 +1,37 @@
-import React, { useState } from "react";
-import Layout from "../../components/Layout";
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import styles from "./StudyRoomList.module.css";
+import { getAuthHeader } from "../../utils/auth";
 
 function StudyRoomList() {
+  const navigate = useNavigate();
   const [rooms, setRooms] = useState([]);
-
   const [showModal, setShowModal] = useState(false);
   const [newRoom, setNewRoom] = useState({
     title: "",
-    maxCapacity: 2,
+    maxCapacity: 4,
     focusMinute: 50,
     breakMinute: 10,
   });
+
+  useEffect(() => {
+    fetchRooms();
+  }, []);
+
+  const fetchRooms = async () => {
+    try {
+      const response = await fetch(`${process.env.REACT_APP_API_BASE_URL}/rooms`, {
+        headers: {
+          Authorization: getAuthHeader(),
+        },
+      });
+      if (!response.ok) throw new Error("Failed to fetch rooms");
+      const data = await response.json();
+      setRooms(data.data);
+    } catch (error) {
+      console.error("Error fetching rooms:", error);
+    }
+  };
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -21,114 +41,130 @@ function StudyRoomList() {
     }));
   };
 
-  const handleCreateRoom = () => {
+  const handleCreateRoom = async () => {
     if (!newRoom.title) {
       alert("방 제목을 입력해주세요.");
       return;
     }
 
-    const newRoomData = {
-      id: rooms.length + 1,
-      title: newRoom.title,
-      current: 1, // 기본 입장 인원 1명
-      max: Number(newRoom.maxCapacity),
-    };
+    try {
+      const response = await fetch(`${process.env.REACT_APP_API_BASE_URL}/rooms`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: getAuthHeader(),
+        },
+        body: JSON.stringify(newRoom),
+      });
 
-    setRooms((prev) => [...prev, newRoomData]);
-    setNewRoom({
-      title: "",
-      maxCapacity: 2,
-      focusMinute: 50,
-      breakMinute: 10,
-    });
-    setShowModal(false);
-    alert("방이 생성되었습니다!");
+      if (!response.ok) throw new Error("Failed to create room");
+
+      const data = await response.json();
+      if (data.status === 200) {
+        alert("방이 생성되었습니다!");
+        navigate(`/rooms/${data.id}`);
+      } else {
+        throw new Error(data.message || "방 생성에 실패했습니다.");
+      }
+    } catch (error) {
+      console.error("Error creating room:", error);
+      alert(error.message || "방 생성에 실패했습니다.");
+    }
+  };
+
+  const handleJoinRoom = (roomId) => {
+    navigate(`/rooms/${roomId}`);
   };
 
   return (
-    <Layout>
-      <div className={styles.wrapper}>
-        <div className={styles.header}>
-          <h2 className={styles.title}>스터디룸 목록</h2>
-          <button
-            className={styles.createBtn}
-            onClick={() => setShowModal(true)}
-          >
-            + 방 만들기
-          </button>
-        </div>
+    <div className={styles.wrapper}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>📋 스터디룸 목록</h2>
+        <button className={styles.createBtn} onClick={() => setShowModal(true)}>
+          + 방 만들기
+        </button>
+      </div>
 
-        {/* ✅ 모달 */}
-        {showModal && (
-          <div className={styles.modalOverlay}>
-            <div className={styles.modal}>
-              <h3>스터디룸 생성</h3>
-              <input
-                type="text"
-                name="title"
-                value={newRoom.title}
-                onChange={handleInputChange}
-                placeholder="방 제목"
-                className={styles.input}
-              />
-              <input
-                type="number"
-                name="focusMinute"
-                placeholder="집중 시간 (분)"
-                value={newRoom.focusMinute}
-                onChange={handleInputChange}
-                className={styles.input}
-              />
-              <input
-                type="number"
-                name="breakMinute"
-                placeholder="휴식 시간 (분)"
-                value={newRoom.breakMinute}
-                onChange={handleInputChange}
-                className={styles.input}
-              />
-              <select
-                name="maxCapacity"
-                value={newRoom.maxCapacity}
-                onChange={handleInputChange}
-                className={styles.select}
-              >
-                {[2, 3, 4, 5, 6].map((num) => (
-                  <option key={num} value={num}>
-                    최대 {num}명
-                  </option>
-                ))}
-              </select>
+      {showModal && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modal}>
+            <h3 className={styles.modalTitle}>📌 새 스터디룸 생성</h3>
+            <label className={styles.label}>방 이름</label>
+            <input
+              type="text"
+              name="title"
+              value={newRoom.title}
+              onChange={handleInputChange}
+              className={styles.input}
+            />
 
-              <div className={styles.formButtons}>
-                <button onClick={handleCreateRoom} className={styles.submitBtn}>
-                  생성
-                </button>
-                <button
-                  onClick={() => setShowModal(false)}
-                  className={styles.cancelBtn}
-                >
-                  취소
-                </button>
+            <div className={styles.modalRow}>
+              <div className={styles.modalColumn}>
+                <label className={styles.label}>집중 시간</label>
+                <input
+                  type="number"
+                  name="focusMinute"
+                  value={newRoom.focusMinute}
+                  onChange={handleInputChange}
+                  className={styles.input}
+                />
               </div>
+              <div className={styles.modalColumn}>
+                <label className={styles.label}>휴식 시간</label>
+                <input
+                  type="number"
+                  name="breakMinute"
+                  value={newRoom.breakMinute}
+                  onChange={handleInputChange}
+                  className={styles.input}
+                />
+              </div>
+            </div>
+            <label className={styles.label}>최대 인원</label>
+            <select
+              name="maxCapacity"
+              value={newRoom.maxCapacity}
+              onChange={handleInputChange}
+              className={styles.select}
+            >
+              {[2, 3, 4, 5, 6].map((num) => (
+                <option key={num} value={num}>
+                  최대 {num}명
+                </option>
+              ))}
+            </select>
+
+            <div className={styles.formButtons}>
+              <button onClick={handleCreateRoom} className={styles.submitBtn}>
+                생성
+              </button>
+              <button onClick={() => setShowModal(false)} className={styles.cancelBtn}>
+                취소
+              </button>
             </div>
           </div>
-        )}
-
-        {/* 방 목록 */}
-        <div className={styles.roomList}>
-          {rooms.map((room) => (
-            <div key={room.id} className={styles.roomCard}>
-              <div className={styles.roomTitle}>{room.title}</div>
-              <div className={styles.roomInfo}>
-                인원: {room.current} / {room.max}
-              </div>
-              <button className={styles.enterBtn}>입장</button>
-            </div>
-          ))}
         </div>
+      )}
+
+      <div className={styles.roomList}>
+        {rooms.map((room) => (
+          <div key={room.id} className={styles.roomCard}>
+            <div className={styles.roomInfoBox}>
+              <div className={styles.roomTitle}>📝 {room.title}</div>
+              <div className={styles.roomInfo}>
+                👥 {room.currentMemberCount} / {room.maxCapacity}
+              </div>
+              <div className={styles.roomTime}>
+                ⏱️ {room.focusMinute}분 집중 / {room.breakMinute}분 휴식
+              </div>
+            </div>
+            <button className={styles.enterBtn} onClick={() => handleJoinRoom(room.id)}>
+              입장
+            </button>
+          </div>
+        ))}
       </div>
-    </Layout>
+    </div>
   );
 }
 

--- a/frontend/src/pages/rooms/StudyRoomList.module.css
+++ b/frontend/src/pages/rooms/StudyRoomList.module.css
@@ -1,6 +1,7 @@
 .wrapper {
-  padding: 40px;
-  max-width: 1000px;
+  padding: 20px;
+  width: 100%;
+  height: 100%;
   margin: 0 auto;
   box-sizing: border-box;
 }
@@ -33,55 +34,64 @@
 }
 
 .roomList {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .roomCard {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 30px;
   border: 1px solid #ddd;
   border-radius: 10px;
-  padding: 20px;
-  background-color: #fafafa;
+  background-color: #fff;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.04);
+  transition: all 0.2s ease;
+}
+
+.roomCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
+}
+
+/* 제목+인원 묶기 */
+.roomInfoBox {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 6px;
 }
 
 .roomTitle {
   font-size: 18px;
-  font-weight: 600;
-  color: #222;
+  font-weight: 700;
+  color: #2a2a2a;
 }
 
 .roomInfo {
   font-size: 14px;
-  color: #666;
+  color: #777;
+}
+
+.roomTime {
+  font-size: 13px;
+  color: #999;
 }
 
 .enterBtn {
-  margin-top: auto;
-  padding: 8px 12px;
-  background-color: #888;
-  color: white;
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  background-color: #666;
+  color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: 8px;
   cursor: pointer;
 }
 
 .enterBtn:hover {
-  background-color: #555;
-}
-.createForm {
-  background-color: #f8f8f8;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  padding: 20px;
-  margin-bottom: 30px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  max-width: 400px;
+  background-color: #357ac9;
 }
 
 .input {
@@ -120,6 +130,7 @@
   border-radius: 5px;
   cursor: pointer;
 }
+
 .modalOverlay {
   position: fixed;
   top: 0;
@@ -131,25 +142,64 @@
   align-items: center;
   justify-content: center;
   z-index: 999;
+  animation: fadeIn 0.2s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .modal {
   background: white;
   padding: 30px;
   border-radius: 10px;
-  width: 300px;
+  width: 320px;
   display: flex;
   flex-direction: column;
   gap: 10px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  transform: scale(0.95);
+  animation: popUp 0.2s ease-in-out forwards;
+  overflow: hidden;
 }
 
-.input,
-.select {
-  padding: 10px;
+@keyframes popUp {
+  to {
+    transform: scale(1);
+  }
+}
+
+.modalTitle {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 10px;
+  color: #222;
+  text-align: center;
+}
+
+.label {
   font-size: 14px;
-  border-radius: 6px;
-  border: 1px solid #aaa;
+  font-weight: 500;
+  margin: 5px 0;
+  color: #444;
+}
+
+.modalRow {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+}
+
+.modalColumn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .formButtons {

--- a/frontend/src/pages/search/SearchID.module.css
+++ b/frontend/src/pages/search/SearchID.module.css
@@ -1,11 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap");
-
-/* 기본 설정 */
-* {
-  box-sizing: border-box;
-  font-family: "Noto Sans KR", sans-serif;
-}
-
 /* 메인 컨테이너 */
 .wrapper {
   display: flex;
@@ -152,12 +144,7 @@
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 255, 255, 0.3),
-    transparent
-  );
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
   transition: all 0.5s;
 }
 

--- a/frontend/src/pages/search/SearchPW.module.css
+++ b/frontend/src/pages/search/SearchPW.module.css
@@ -1,11 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap");
-
-/* 기본 설정 */
-* {
-  box-sizing: border-box;
-  font-family: "Noto Sans KR", sans-serif;
-}
-
 /* 메인 컨테이너 */
 .wrapper {
   display: flex;
@@ -141,12 +133,7 @@
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 255, 255, 0.3),
-    transparent
-  );
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
   transition: all 0.5s;
 }
 

--- a/frontend/src/pages/signup/Signup.module.css
+++ b/frontend/src/pages/signup/Signup.module.css
@@ -1,11 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap");
-
-/* 기본 설정 */
-* {
-  box-sizing: border-box;
-  font-family: "Noto Sans KR", sans-serif;
-}
-
 /* 메인 컨테이너 */
 .wrapper {
   display: flex;
@@ -163,12 +155,7 @@
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 255, 255, 0.3),
-    transparent
-  );
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent);
   transition: all 0.5s;
 }
 


### PR DESCRIPTION
## 요약
- 스터디룸 목록 조회 및 생성 기능을 API와 연동하고, 전체적인 UI와 레이아웃을 개선.
- Pretendard 폰트를 전역에 적용하여 일관성 확보.

<br><br>

## 작업 내용
- 전역 폰트 Pretendard 적용 (index.css에 CDN import 및 body 적용)
- 스터디룸 목록 조회 및 생성 기능을 백엔드 API와 연동
- 스터디룸 목록 UI 전면 리팩토링
  - 카드 레이아웃 → 한 줄씩 쌓이는 리스트 형식으로 변경
  - 입장 버튼, 방 정보, 집중/휴식 시간 등의 스타일 개선
  - 모달 UI 개선 (입력 필드 정렬, 제목/레이블 추가)
- 모달 팝업 애니메이션 및 오버레이 스타일링 추가
<br><br>

## 참고 사항
- 방 생성 시 `navigate`를 통해 생성된 방으로 바로 이동
- 현재, 사이드바는 오버레이에 포함되지 않음 
<br><br>

## 관련 이슈

- Close #XXX

<br><br>
