### PR TITLE
feat: JWT 클레임 닉네임 변경 및 인증 실패 처리 적용

### DIFF
--- a/backend/src/main/java/com/swu/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/swu/auth/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.swu.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"message\":\"인증이 필요합니다.\"}");
+    }
+}

--- a/backend/src/main/java/com/swu/auth/jwt/JWTUtil.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTUtil.java
@@ -20,13 +20,13 @@ public class JWTUtil {
         this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
     }
 
-    public String getUsername(String token) {
+    public String getNickname(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(secretKey)
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
-                .get("username", String.class);
+                .get("nickname", String.class);
     }
 
     public Integer getId(String token) {
@@ -57,11 +57,11 @@ public class JWTUtil {
                 .before(new Date());
     }
 
-    public String createJwt (String username, String role, Long Id, Long expiredMs) {
+    public String createJwt (String nickname, String role, Long Id, Long expiredMs) {
         Date now = new Date();
         Date expirationDate = new Date(now.getTime() + expiredMs);
         return Jwts.builder()
-                .claim("username", username)
+                .claim("nickname", nickname)
                 .claim("id", Id)
                 .claim("role", role.replace("ROLE_", ""))
                 .setIssuedAt(new Date(System.currentTimeMillis()))

--- a/backend/src/main/java/com/swu/config/SecurityConfig.java
+++ b/backend/src/main/java/com/swu/config/SecurityConfig.java
@@ -1,8 +1,12 @@
 package com.swu.config;
 
+import com.swu.auth.handler.CustomAuthenticationEntryPoint;
 import com.swu.auth.jwt.JWTFilter;
 import com.swu.auth.jwt.JWTUtil;
 import com.swu.auth.jwt.LoginFilter;
+
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -14,15 +18,13 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JWTUtil jwtUtil;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint; 
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil) {
-        this.authenticationConfiguration = authenticationConfiguration;
-        this.jwtUtil = jwtUtil;
-    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -46,7 +48,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**", "/ws/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 );
-
+        http
+                .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(customAuthenticationEntryPoint) 
+                );       
         http
                 .addFilterAt(new LoginFilter(authenticationConfiguration.getAuthenticationManager(), jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new JWTFilter(jwtUtil), LoginFilter.class);

--- a/backend/src/main/java/com/swu/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/swu/domain/user/service/UserService.java
@@ -7,9 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.swu.domain.user.dto.request.SignupRequest;
 import com.swu.domain.user.dto.response.UserInfoResponse;
-import com.swu.domain.user.entity.Grade;
-import com.swu.domain.user.entity.LoginType;
-import com.swu.domain.user.entity.Role;
 import com.swu.domain.user.entity.User;
 import com.swu.domain.user.exception.EmailAlreadyExistsException;
 import com.swu.domain.user.exception.InvalidCurrentPasswordException;


### PR DESCRIPTION
## 요약
JWT 토큰 클레임 정보를 이메일에서 닉네임으로 변경하고, 인증 실패 시 CustomAuthenticationEntryPoint를 통해 일관된 401 응답을 반환하는 로직을 추가함.

<br><br>

## 작업 내용
- JWTUtil 수정: 클레임에 nickname 포함 (기존 email 제외시킴)
- LoginFilter 수정: 로그인 시 nickname을 사용하여 JWT 발급
- SecurityConfig 수정: CustomAuthenticationEntryPoint 등록
- CustomAuthenticationEntryPoint 클래스 추가
- 인증 실패 시 401 상태와 JSON 응답 반환
<br><br>

## 참고 사항
- 기존 이메일 기반 클레임은 모두 삭제
- 프론트엔드 헤더에서 유저닉네임을 토큰에서 읽어오는 방향으로 수정 예정

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>
