### PR TITLE
feat: 레이아웃 리팩터링 및 JWT 기반 닉네임 표시 개선

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3900,6 +3900,17 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
+      "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,42 +1,27 @@
 import styles from "./Header.module.css";
 import { useState, useEffect } from "react";
-import { getAuthHeader } from "../utils/auth";
+import { getNicknameFromToken, removeToken } from "../utils/auth";
+import { FiClock } from "react-icons/fi";
 
 const Header = () => {
-  // 공부 시간을 표시할 상태 (실제 기능 없이 UI만 표시)
-  const [studyTime, setStudyTime] = useState("3시간 45분");
+  const [studyTime, setStudyTime] = useState("00시간 00분");
   const [currentTime, setCurrentTime] = useState(new Date());
-  const [userName, setUserName] = useState("");
+  const nickname = getNicknameFromToken();
 
-  // 현재 시간 업데이트 (UI 목적으로만 사용)
+  const handleLogout = () => {
+    removeToken();
+    window.location.href = "/";
+  };
+
+  // 현재 시간
   useEffect(() => {
     const timer = setInterval(() => {
       setCurrentTime(new Date());
-    }, 60000); // 1분마다 업데이트
+    }, 60000);
 
     return () => clearInterval(timer);
   }, []);
 
-  useEffect(() => {
-    const fetchUserInfo = async () => {
-      try {
-        const res = await fetch(`${process.env.REACT_APP_API_BASE_URL}/users/me`, {
-          headers: {
-            Authorization: getAuthHeader(),
-          },
-        });
-        if (!res.ok) throw new Error("유저 정보 조회 실패");
-
-        const data = await res.json();
-        setUserName(data.data.nickname); // nickname만 추출
-      } catch (err) {
-        console.error(err);
-        setUserName("유저");
-      }
-    };
-
-    fetchUserInfo();
-  }, []);
   // 시간 표시 포맷
   const formattedTime = currentTime.toLocaleTimeString("ko-KR", {
     hour: "2-digit",
@@ -47,18 +32,23 @@ const Header = () => {
   return (
     <header className={styles.header}>
       <div className={styles.leftSection}>
-        <div className={styles.clockSection}>
-          <div className={styles.clockIcon}>🕓</div>
-          <div className={styles.timeInfo}>
-            <div className={styles.currentTime}>{formattedTime}</div>
-            <div className={styles.studyTime}>오늘 공부시간: {studyTime}</div>
-          </div>
+        <FiClock style={{ fontSize: "2.2rem" }} />
+        <div className={styles.timeInfo}>
+          <div className={styles.currentTime}>{formattedTime}</div>
+          <div className={styles.studyTime}>오늘 공부시간: {studyTime}</div>
         </div>
       </div>
       <div className={styles.rightSection}>
-        <div className={styles.greeting}>
-          <span className={styles.userName}>{userName}</span>님
-        </div>
+        {nickname ? (
+          <>
+            <span className={styles.userName}>{nickname}님</span>
+            <span className={styles.logout} onClick={handleLogout}>
+              로그아웃
+            </span>
+          </>
+        ) : (
+          <span className={styles.guestMessage}>로그인이 필요합니다</span>
+        )}
       </div>
     </header>
   );

--- a/frontend/src/components/Header.module.css
+++ b/frontend/src/components/Header.module.css
@@ -1,32 +1,15 @@
 .header {
-  height: 70px;
-  position: fixed;
-  top: 0;
-  left: 100px;
-  right: 0;
-  z-index: 900;
+  height: 4rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 30px;
-  background: linear-gradient(to right, #f5f5f5, #e9e9e9);
-  border-bottom: 1px solid #e2e8f0;
+  padding: 1rem 1.5rem;
 }
 
 .leftSection {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.clockSection {
-  display: flex;
   align-items: center;
-}
-
-.clockIcon {
-  font-size: 24px;
-  margin-right: 10px;
+  gap: 0.5rem;
 }
 
 .timeInfo {
@@ -35,23 +18,25 @@
 }
 
 .currentTime {
-  font-size: 18px;
+  font-size: 1.2rem;
   font-weight: 500;
   color: #333;
 }
 
 .studyTime {
-  font-size: 14px;
+  font-size: 0.8rem;
   color: #666;
 }
 
 .rightSection {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 1rem;
+  color: #222;
+  font-weight: 600;
 }
 
-.userName {
-  font-weight: 600;
-  color: #222;
+.logout {
+  cursor: pointer;
+  text-decoration: underline;
 }

--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -1,18 +1,20 @@
 .layout {
   width: 100vw;
   height: 100vh;
+  display: flex;
 }
 
 .mainSection {
+  flex: 1;
   height: 100vh;
   display: flex;
   flex-direction: column;
-  margin-left: 100px;
   overflow: hidden;
+  background-color: #e2d1c3;
 }
 
 .content {
   flex: 1;
   overflow-y: auto;
-  margin-top: 70px;
+  padding: 1rem 1.5rem;
 }

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -2,19 +2,12 @@ import { Link, useLocation } from "react-router-dom";
 import { FaChalkboardTeacher, FaCalendarAlt, FaBookOpen, FaUserCircle } from "react-icons/fa";
 import styles from "./Sidebar.module.css";
 import logoImage from "../assets/images/StudywithusLogo.png";
-import { removeToken } from "../utils/auth";
-import logoutImage from "../assets/images/logout.png";
 
 const Sidebar = () => {
   const location = useLocation();
 
   const isActive = (path) => {
     return location.pathname === path ? styles.active : "";
-  };
-
-  const handleLogout = () => {
-    removeToken();
-    window.location.href = "/";
   };
 
   const menuLinks = [
@@ -26,28 +19,20 @@ const Sidebar = () => {
 
   return (
     <div className={styles.sidebar}>
-      <div className={styles.logo}>
-        <img src={logoImage} alt="Study Planner Logo" className={styles.logoImg} />
-      </div>
+      <img src={logoImage} alt="Study_With_Us_Logo" className={styles.logo} />
 
-      <nav className={styles.navigation}>
-        <ul className={styles.navList}>
+      <nav>
+        <ul className={styles.menuList}>
           {menuLinks.map((menu) => (
             <li key={menu.path}>
-              <Link to={menu.path} className={`${styles.navLink} ${isActive(menu.path)}`}>
-                <div className={styles.iconBox}>{menu.icon}</div>
-                <span className={styles.linkLabel}>{menu.label}</span>
+              <Link to={menu.path} className={`${styles.menuLink} ${isActive(menu.path)}`}>
+                <div className={styles.icon}>{menu.icon}</div>
+                <span className={styles.label}>{menu.label}</span>
               </Link>
             </li>
           ))}
         </ul>
       </nav>
-      <div className={styles.authLinks}>
-        <button className={styles.authLink} onClick={handleLogout}>
-          <img src={logoutImage} alt="로그아웃" className={styles.logoutIcon} />
-          <span className={styles.linkLabel}>로그아웃</span>
-        </button>
-      </div>
     </div>
   );
 };

--- a/frontend/src/components/Sidebar.module.css
+++ b/frontend/src/components/Sidebar.module.css
@@ -3,124 +3,61 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
-  border-right: 1px solid #e0e0e0;
-  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.05);
-
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 1000;
+  background: linear-gradient(135deg, #c79081, #dfa579 100%);
+  gap: 20px;
 }
 
 .logo {
-  text-align: center;
-  padding: 15px 0 15px;
-}
-
-.logoImg {
-  width: 95px;
-  height: auto;
+  display: block;
+  margin: 0 auto;
+  width: 100%;
   object-fit: contain;
+  filter: brightness(0) invert(1);
+  padding: 15px 0;
+  cursor: pointer;
 }
 
-.navigation {
-  flex: 1;
-  margin-top: 20px;
-}
-
-.navList {
+.menuList {
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 20px;
 }
 
-.navList li {
-  margin: 10px 0;
+.menuList li {
   width: 100%;
   text-align: center;
 }
 
-.navLink {
+.menuLink {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   padding: 12px 5px;
   text-decoration: none;
-  color: #444;
-  font-size: 14px;
-  font-weight: 500;
-  transition: all 0.3s;
-  width: 90%;
+  transition: background-color 0.3s, border-radius 0.3s;
   cursor: pointer;
+  color: #ffffff;
+  gap: 5px;
 }
 
-.iconBox {
-  margin-bottom: 8px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 30px;
-}
-
-.linkLabel {
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.navLink:hover {
-  width: 100%;
-  background: linear-gradient(to right, #f0f0f0, #e6e6e6);
-  color: #222;
-}
-
+.menuLink:hover,
 .active {
-  width: 100%;
-  background: linear-gradient(to right, #e0e0e0, #d6d6d6);
-  color: #000 !important;
-  font-weight: 600;
-  border-left: 4px solid #999;
+  background: #b96852;
+  border-radius: 15px;
 }
 
-.authLinks {
-  padding: 20px;
+.icon {
   display: flex;
   justify-content: center;
-}
-
-.authLink {
-  display: flex;
-  flex-direction: column;
   align-items: center;
-  /* gap: 6px; */
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #555;
-  font-size: 14px;
-  padding: 5px;
-  border-radius: 6px;
-  transition: background-color 0.3s;
 }
 
-.authLink:hover {
-  background-color: #e9e9e9;
-}
-
-.logoutIcon {
-  width: 30x;
-  height: 30px;
-}
-@media (max-width: 768px) {
-  .sidebar {
-    width: 180px;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
-  }
-
-  .sidebar.open {
-    transform: translateX(0);
-  }
+.label {
+  font-size: 16px;
+  font-weight: 500;
 }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { toast } from "react-toastify";
 import { getAuthHeader } from "./auth";
 
 const apiClient = axios.create({
@@ -24,8 +23,12 @@ apiClient.interceptors.response.use(
   (error) => {
     const status = error.response?.status;
 
-    if (status >= 500) {
-      toast.error("서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    console.log("API 에러 발생", error);
+    if (status === 401) {
+      alert("로그인이 필요합니다. 다시 로그인 해주세요.");
+      window.location.href = "/login";
+    } else if (status >= 500) {
+      alert("서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
     }
 
     return Promise.reject(error);
@@ -34,6 +37,7 @@ apiClient.interceptors.response.use(
 
 // 응답 핸들링
 const handleResponse = (response) => {
+  console.log("API 응답", response);
   return response.data.data;
 };
 

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -27,3 +27,32 @@ export const extractTokenFromHeader = (res) => {
   const [scheme, token] = authHeader.split(" ");
   return scheme === "Bearer" ? token : null;
 };
+
+export const parseTokenPayload = () => {
+  const token = getToken();
+  if (!token) return null;
+
+  try {
+    const payloadBase64 = token.split(".")[1];
+
+    // base64url 포맷을 base64로 변환
+    const base64 = payloadBase64.replace(/-/g, "+").replace(/_/g, "/");
+    const decodedPayload = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map(function (c) {
+          return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+        })
+        .join("")
+    );
+    return JSON.parse(decodedPayload);
+  } catch (error) {
+    console.error("Failed to parse token payload:", error);
+    return null;
+  }
+};
+
+export const getNicknameFromToken = () => {
+  const payload = parseTokenPayload();
+  return payload ? payload.nickname : null;
+};


### PR DESCRIPTION
## 요약
사이드바, 헤더, 메인섹션 등 레이아웃 CSS 구조를 리팩터링하고, JWT 토큰 기반으로 사용자 닉네임을 표시하는 방식으로 개선.
또한 Axios 응답 인터셉터를 추가하여 401 에러 시 로그인 페이지로 자동 이동하도록 처리.

<br><br>

## 작업 내용
- 사이드바, 헤더, 메인 섹션, 컨텐츠 영역 CSS 리팩터링
- 사이드바 로그아웃 버튼 제거 → 헤더로 이동
- 메인 컬러 지정 (사이드바, 메인섹션 배경색)
- Header.js에서 JWT 토큰에서 닉네임 직접 파싱
- auth.js 유틸에 `getNicknameFromToken` 추가
- api.js 응답 인터셉터 수정
  -  401 → 로그인 이동
  -  500 이상 -> alert 처리

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>
