### PR TITLE
feat: StudyRoom 구현 (STOMP, WebRTC, Chat) 

### DIFF
--- a/backend/src/main/java/com/swu/controller/SignalingController.java
+++ b/backend/src/main/java/com/swu/controller/SignalingController.java
@@ -31,40 +31,46 @@ public class SignalingController {
             if (!(principal instanceof UsernamePasswordAuthenticationToken authToken)) {
                 throw new SecurityException("인증되지 않은 사용자입니다.");
             }
-            
-            // 인증된 사용자 정보 추출
+    
             CustomUserDetails userDetails = (CustomUserDetails) authToken.getPrincipal();
             User user = userDetails.getUser();
-
-            // 방 접근 권한 검사
+    
             if (!roomService.hasAccessToRoom(message.roomId(), user)) {
                 throw new SecurityException("방에 입장할 권한이 없습니다.");
             }
+    
+            log.debug("시그널 메시지 수신 - 타입: {}, 방: {}, 발신자: {}, 수신자: {}",
+    
+            message.type(), message.roomId(), message.senderNickname(), message.targetId());
 
-            log.debug("시그널 메시지 수신 - 타입: {}, 방: {}, 발신자: {}", 
-                    message.type(), message.roomId(), message.senderNickname());
-
-            String destination = "/sub/room/" + message.roomId();
-            messagingTemplate.convertAndSend(destination, message);
+            String destination;
+            if (message.targetId() != null) {
+                destination = "/sub/user/" + message.targetId();
+            } else {
+                destination = "/sub/room/" + message.roomId();
+            }
+            log.debug("전송할 목적지: {}", destination);
+            log.debug("전송할 메시지: {}", message);
+            messagingTemplate.convertAndSend(destination, message);  
         } catch (SecurityException se) {
             log.warn("시큐리티 예외 발생: {}", se.getMessage());
-
+    
             SignalingMessage errorMessage = SignalingMessage.createError(
-                message.roomId(),
-                message.senderId(),
-                message.senderNickname(),
-                se.getMessage()
+                    message.roomId(),
+                    message.senderId(),
+                    message.senderNickname(),
+                    se.getMessage()
             );
-            messagingTemplate.convertAndSend("/sub/room/" + message.roomId(), errorMessage);
+            messagingTemplate.convertAndSend("/sub/user/" + message.senderId(), errorMessage);
         } catch (Exception e) {
             log.error("시그널 처리 중 오류 발생: {}", e.getMessage());
             SignalingMessage errorMessage = SignalingMessage.createError(
-                message.roomId(),
-                message.senderId(),
-                message.senderNickname(),
-                e.getMessage()
+                    message.roomId(),
+                    message.senderId(),
+                    message.senderNickname(),
+                    e.getMessage()
             );
-            messagingTemplate.convertAndSend("/sub/room/" + message.roomId(), errorMessage);
+            messagingTemplate.convertAndSend("/sub/user/" + message.senderId(), errorMessage);
         }
     }
 }

--- a/backend/src/main/java/com/swu/domain/room/dto/message/SignalingMessage.java
+++ b/backend/src/main/java/com/swu/domain/room/dto/message/SignalingMessage.java
@@ -23,6 +23,9 @@ public record SignalingMessage(
     @NotBlank(message = "발신자 닉네임은 필수입니다.")
     String senderNickname,
     
+    @Schema(description = "수신자 ID (필요 시)")
+    Long targetId,
+
     @NotNull(message = "데이터는 필수입니다.")
     Object data
 ) {
@@ -34,7 +37,7 @@ public record SignalingMessage(
         }
     }
     
-    public static SignalingMessage createError(Long roomId, Long senderId, String senderNickname, String errorMessage) {
-        return new SignalingMessage("error", roomId, senderId, senderNickname, errorMessage);
+   public static SignalingMessage createError(Long roomId, Long senderId, String senderNickname, String errorMessage) {
+        return new SignalingMessage("error", roomId, senderId, senderNickname, null, errorMessage);
     }
 } 

--- a/backend/src/main/java/com/swu/domain/room/listener/RedisMessageSubscriber.java
+++ b/backend/src/main/java/com/swu/domain/room/listener/RedisMessageSubscriber.java
@@ -27,7 +27,7 @@ public class RedisMessageSubscriber implements MessageListener {
             String body = new String(message.getBody());
             ChatMessage chatMessage = objectMapper.readValue(body, ChatMessage.class);
 
-            String destination = "/sub/chat/room/" + chatMessage.roomId();
+            String destination = "/sub/room/chat" + chatMessage.roomId();
             messagingTemplate.convertAndSend(destination, chatMessage);
             log.debug("Redis로부터 수신한 메시지를 전송함 - 방: {}", chatMessage.roomId());
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,7 +9,7 @@ import Diary from "./pages/diary/Diary";
 import Planer from "./pages/planer/Planer";
 import StudyRoomList from "./pages/rooms/StudyRoomList";
 import LandingPage from "./pages/landing/LandingPage";
-// import StudyRoom from "./pages/rooms/StudyRoom";
+import StudyRoom from "./pages/rooms/StudyRoom";
 
 import { isAuthenticated } from "./utils/auth";
 
@@ -47,7 +47,7 @@ function App() {
           <Route path="/diary" element={<Diary />} />
           <Route path="/planer" element={<Planer />} />
           <Route path="/rooms" element={<StudyRoomList />} />
-          {/* <Route path="/rooms/:roomId" element={<StudyRoom />} /> */}
+          <Route path="/rooms/:roomId" element={<StudyRoom />} />
         </Route>
 
         {/* 🔁 잘못된 경로 → 홈으로 리다이렉트 */}

--- a/frontend/src/components/Chat/Chat.module.css
+++ b/frontend/src/components/Chat/Chat.module.css
@@ -1,0 +1,69 @@
+.chatSection {
+  width: 20%;
+  min-width: 300px;
+  max-width: 400px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  background-color: #fff;
+  height: 100%;
+}
+
+.chatHeader {
+  padding: 10px 20px;
+  border-bottom: #ddd 1px solid;
+  font-weight: 600;
+  font-size: 20px;
+}
+
+.chatMessages {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 10px;
+  padding: 10px;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
+.chatInput {
+  display: flex;
+  gap: 8px;
+  padding: 10px 10px;
+}
+
+.chatInput input {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.chatInput button {
+  padding: 8px 16px;
+  background-color: #8b4513;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+@media (max-width: 1000px) {
+  .chatSection {
+    width: 100%;
+    max-width: 100%;
+    height: 300px;
+  }
+  .chatHeader {
+    display: none;
+  }
+}
+
+@media (max-width: 500px) {
+  .chatSection {
+    width: 100%;
+    max-width: 100%;
+    height: 300px;
+    max-height: 150px;
+  }
+}

--- a/frontend/src/components/Chat/ChatInput.js
+++ b/frontend/src/components/Chat/ChatInput.js
@@ -1,0 +1,17 @@
+import styles from "./Chat.module.css";
+
+const ChatInput = ({ chatInput, handleSendChat }) => {
+  return (
+    <div className={styles.chatInput}>
+      <input
+        type="text"
+        placeholder="메시지 입력..."
+        ref={chatInput}
+        onKeyUp={(e) => e.key === "Enter" && handleSendChat()}
+      />
+      <button onClick={handleSendChat}>전송</button>
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/frontend/src/components/Chat/ChatMessages.js
+++ b/frontend/src/components/Chat/ChatMessages.js
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+import styles from "./Chat.module.css";
+
+const ChatMessages = ({ chatMessages }) => {
+  const scrollRef = useRef();
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [chatMessages]);
+
+  return (
+    <div className={styles.chatMessages}>
+      {chatMessages.map((msg, idx) => (
+        <div key={idx}>
+          <strong>{msg.senderNickname}</strong>: {msg.message}
+        </div>
+      ))}
+      <div ref={scrollRef} />
+    </div>
+  );
+};
+
+export default ChatMessages;

--- a/frontend/src/components/Chat/ChatSection.js
+++ b/frontend/src/components/Chat/ChatSection.js
@@ -1,0 +1,15 @@
+import ChatMessages from "./ChatMessages";
+import ChatInput from "./ChatInput";
+import styles from "./Chat.module.css";
+
+const ChatSection = ({ chatMessages, chatInput, handleSendChat }) => {
+  return (
+    <div className={styles.chatSection}>
+      <div className={styles.chatHeader}>채팅</div>
+      <ChatMessages chatMessages={chatMessages} />
+      <ChatInput chatInput={chatInput} handleSendChat={handleSendChat} />
+    </div>
+  );
+};
+
+export default ChatSection;

--- a/frontend/src/components/Loading.js
+++ b/frontend/src/components/Loading.js
@@ -1,0 +1,26 @@
+const Loading = () => {
+  return (
+    <>
+      <style>
+        {`
+                    .loader {
+                        border: 16px solid #f3f3f3;
+                        border-top: 16px solid #b96852;
+                        border-radius: 50%;
+                        width: 60px;
+                        height: 60px;
+                        animation: spin 1s linear infinite;
+                    }
+
+                    @keyframes spin {
+                        0% { transform: rotate(0deg); }
+                        100% { transform: rotate(360deg); }
+                    }
+                `}
+      </style>
+      <div className="loader"></div>
+    </>
+  );
+};
+
+export default Loading;

--- a/frontend/src/components/Video/VideoPlayer.js
+++ b/frontend/src/components/Video/VideoPlayer.js
@@ -1,0 +1,23 @@
+import styles from "./VideoSection.module.css";
+
+const VideoPlayer = ({ stream, nickname, muted = false }) => {
+  return (
+    <div className={styles.videoContainer}>
+      <video
+        className={styles.video}
+        ref={(video) => {
+          if (video) {
+            video.srcObject = stream;
+            video.play().catch(() => {});
+          }
+        }}
+        muted={muted}
+        autoPlay
+        playsInline
+      />
+      <div className={styles.nickname}>{nickname}</div>
+    </div>
+  );
+};
+
+export default VideoPlayer;

--- a/frontend/src/components/Video/VideoPlayer.module.css
+++ b/frontend/src/components/Video/VideoPlayer.module.css
@@ -1,0 +1,31 @@
+.videoContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  background-color: #000;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  aspect-ratio: 4 / 3;
+  width: 100%;
+}
+
+.video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.nickname {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  background: rgba(0, 0, 0, 0.65);
+  color: white;
+  padding: 3px 8px;
+  font-size: 13px;
+  border-radius: 8px;
+  font-weight: 500;
+  pointer-events: none;
+}

--- a/frontend/src/components/Video/VideoSection.js
+++ b/frontend/src/components/Video/VideoSection.js
@@ -1,0 +1,47 @@
+import styles from "./VideoSection.module.css";
+import VideoPlayer from "./VideoPlayer";
+
+const VideoSection = ({ myStream, others, myNickname, room }) => {
+  const participantCount = (myStream ? 1 : 0) + others.length;
+
+  let gridClass = styles.grid2x2; // 기본은 2x2
+  if (participantCount <= 1) {
+    gridClass = styles.grid1x1;
+  } else if (participantCount === 2) {
+    gridClass = styles.grid1x2;
+  } else if (participantCount <= 4) {
+    gridClass = styles.grid2x2;
+  } else if (participantCount <= 6) {
+    gridClass = styles.grid2x3;
+  }
+
+  return (
+    <div className={styles.section}>
+      {room && (
+        <div className={styles.roomHeader}>
+          <div>
+            <h2 className={styles.roomTitle}>방 제목: {room.title}</h2>
+            <p className={styles.roomMeta}>인원 제한: {room.maxCapacity}명</p>
+          </div>
+          <div>
+            {/* <div className={styles.timer}>
+              <h3>타이머 섹션 = 구현 예정</h3>
+            </div> */}
+          </div>
+        </div>
+      )}
+      <div className={`${styles.videoGrid} ${gridClass}`}>
+        {myStream && <VideoPlayer stream={myStream} nickname={myNickname} muted={true} />}
+        {others.map((other) => (
+          <VideoPlayer key={other.peerId} stream={other.stream} nickname={other.nickname} />
+        ))}
+      </div>
+      <div className={styles.videoControls}>
+        <button className={styles.controlButton}>비디오 끄기</button>
+        <button className={styles.controlButtonExit}>방 나가기</button>
+      </div>
+    </div>
+  );
+};
+
+export default VideoSection;

--- a/frontend/src/components/Video/VideoSection.module.css
+++ b/frontend/src/components/Video/VideoSection.module.css
@@ -1,0 +1,163 @@
+.section {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.roomHeader {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px;
+  border-bottom: 1px solid #ddd;
+  border-radius: 10px 10px 0px 0px;
+  max-height: 10rem;
+  align-items: center;
+}
+.roomTitle {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: #181a27;
+}
+
+.roomMeta {
+  font-size: 14px;
+  color: #666;
+}
+
+.timer {
+  width: 300px;
+  height: 30px;
+  border-radius: 20px;
+  font-size: 16px;
+  font-weight: bold;
+  background-color: orange;
+  color: white;
+  text-align: center;
+}
+/* 비디오 그리드 */
+.videoGrid {
+  display: grid;
+  height: 100%;
+  gap: 8px;
+  padding: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+.grid1x1 {
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+}
+
+.grid1x2 {
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: 1fr;
+}
+
+.grid2x2 {
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+}
+
+.grid2x3 {
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+}
+
+/* 하나의 비디오 */
+.videoContainer {
+  aspect-ratio: 4 / 3;
+  width: 100%;
+  max-height: 100%;
+  background-color: #000;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  position: relative;
+}
+
+.video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.nickname {
+  position: absolute;
+  bottom: 6px;
+  left: 6px;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 3px 8px;
+  font-size: 13px;
+  border-radius: 6px;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+.hostBadge {
+  background-color: gold;
+  color: black;
+  font-size: 10px;
+  font-weight: bold;
+  padding: 2px 6px;
+  margin-left: 6px;
+  border-radius: 4px;
+}
+
+.videoControls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  padding: 10px 20px;
+  /* background-color: #f5f5f5; */
+  /* border-radius: 12px; */
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+  /* box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1); */
+}
+
+.controlButton {
+  all: unset;
+  padding: 8px 16px;
+  background-color: #8b4513;
+  color: white;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.controlButtonExit {
+  all: unset;
+  padding: 8px 16px;
+  background-color: #d32f2f;
+  color: white;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.controlButton:hover {
+  background-color: #743204;
+}
+
+.controlButtonExit:hover {
+  background-color: #b71c1c;
+}

--- a/frontend/src/hooks/useChat.js
+++ b/frontend/src/hooks/useChat.js
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * 채팅 웹소켓 연결 및 메시지 송수신을 담당하는 커스텀 훅
+ */
+export const useChat = (roomId, user, stompClientRef, isConnected ) => {
+  const [chatMessages, setChatMessages] = useState([]); 
+  const chatInputRef = useRef();
+
+  const sendChat = (msg) => {
+    if (stompClientRef.current?.connected) {
+      stompClientRef.current.publish({
+        destination: "/pub/chat/message",
+        body: JSON.stringify(msg),
+      });
+    } else {
+      console.warn("채팅 전송 실패: STOMP 연결 안됨");
+    }
+  };
+
+  const handleSendChat = () => {
+    const message = chatInputRef.current?.value.trim();
+    if (!message || !user) return;
+
+    if (message.length > 200) {
+      alert("메시지는 200자 이내로 입력해주세요.");
+      chatInputRef.current.value = "";
+      return;
+    }
+
+    console.log("💬 채팅 전송:", message);
+    sendChat({
+      type: "TALK",
+      roomId: Number(roomId),
+      senderId: user.id,
+      senderNickname: user.nickname,
+      message,
+    });
+
+    chatInputRef.current.value = "";
+  };
+
+  useEffect(() => {
+    const client = stompClientRef.current;
+    if (!client || !isConnected || !user) return;
+
+    const subscription = client.subscribe(`/sub/chat/room/${roomId}`, (msg) => {
+      const payload = JSON.parse(msg.body);
+      console.log("💬 채팅 수신:", payload);
+      setChatMessages((prev) => [...prev, payload]);
+    });
+
+    return () => {
+      subscription?.unsubscribe();
+    };
+  }, [stompClientRef, user, roomId, isConnected]);
+
+  useEffect(() => {
+    if (!isConnected || !user) return;
+  
+    // 입장 메시지
+    sendChat({
+      type: "ENTER",
+      roomId: Number(roomId),
+      senderId: user.id,
+      senderNickname: user.nickname,
+      message: `${user.nickname}님이 입장하셨습니다.`,
+    });
+  
+    // 클린업 시 퇴장 메시지 전송
+    return () => {
+      sendChat({
+        type: "EXIT",
+        roomId: Number(roomId),
+        senderId: user.id,
+        senderNickname: user.nickname,
+        message: `${user.nickname}님이 퇴장하셨습니다.`,
+      });
+    };
+  }, [isConnected, user]);
+  
+
+  return { chatMessages, chatInputRef, handleSendChat };
+};

--- a/frontend/src/hooks/useCurrentUser.js
+++ b/frontend/src/hooks/useCurrentUser.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+import { apiGet } from "../utils/api";
+
+const useCurrentUser = () => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const data = await apiGet("/users/me");
+        setUser(data);
+      } catch (err) {
+        console.error("유저 정보 불러오기 실패", err);
+      }
+    };
+
+    fetchUser();
+  }, []);
+
+  return user;
+};
+
+export default useCurrentUser;

--- a/frontend/src/hooks/useStompClient.js
+++ b/frontend/src/hooks/useStompClient.js
@@ -1,0 +1,58 @@
+// hooks/useStompClient.js
+import { Client } from "@stomp/stompjs";
+import SockJS from "sockjs-client";
+import { getAuthHeader } from "../utils/auth";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * 전역 STOMP 클라이언트를 생성하고 재사용하는 훅
+ * - 하나의 웹소켓 클라이언트를 앱 전체에서 공유
+ * - 최초 1회만 소켓 연결을 생성하고, 이후에는 재사용
+ * - 연결 상태도 반환 (isConnected)
+ */
+
+let sharedClient = null; // 전역 공유 클라리언트
+
+export const useStompClient = () => {
+  const clientRef = useRef(null); // 이 훅의 반환값으로 사용할 참조
+  const [isConnected, setIsConnected] = useState(false); // 연결 상태
+
+  // 최초 한 번만 클라이언트 생성
+  if (!sharedClient) {
+    const socket = new SockJS(`${process.env.REACT_APP_WS_BASE_URL}/ws`);
+    const client = new Client({
+      webSocketFactory: () => socket, 
+      connectHeaders: {
+        Authorization: getAuthHeader(),
+      },
+      reconnectDelay: 3000, // 연결 끊겼을 때 재시도 간격(ms)
+      onConnect: () => {
+        console.log("STOMP 클라이언트 연결됨");
+        setIsConnected(true);
+      },
+      onDisconnect: () => {
+        console.log("STOMP 클라이언트 연결 끊김");
+        setIsConnected(false);
+      },
+      onStompError: (frame) => {
+        console.error("STOMP 에러", frame.headers.message);
+        setIsConnected(false);
+      },
+    });
+
+    sharedClient = client;
+    client.activate(); // 연결 시작
+  }
+
+  useEffect(() => {
+    clientRef.current = sharedClient; // 현재 훅에 클라이언트 주입
+
+    return () => {
+      sharedClient.deactivate(); // 연결 종료
+      sharedClient = null; // 전역 클라 제거
+      console.log("STOMP 연결 종료됨");   
+     };
+  }, []);
+
+  return { stompClientRef: clientRef, isConnected }; // 클라이언트와 연결 상태 반환
+};

--- a/frontend/src/hooks/useWebRTC.js
+++ b/frontend/src/hooks/useWebRTC.js
@@ -1,0 +1,243 @@
+import { useEffect, useRef, useState } from "react";
+import { apiGet } from "../utils/api";
+
+export const useWebRTC = (roomId, user, localStream, stompClientRef, isConnected) => {
+  const peerConnections = useRef({});
+  const [remoteStreams, setRemoteStreams] = useState([]);
+  const pendingCandidates = useRef({});
+  
+  // 방에 있는 기존 사용자 목록을 가져와서 연결
+  const fetchExistingUsersAndConnect = async () => {
+    try {
+      const res = await apiGet(`/rooms/${roomId}/members`);
+      console.log("기존 방 사용자 불러오기 성공", res);
+      for (const member of res) {
+        if (member.userId === user.id) continue; // 나 자신은 스킵
+        await createPeerConnection(member.userId, member.nickname, true); // 내가 initiator
+      }
+    } catch (e) {
+      console.error("기존 방 사용자 불러오기 실패", e);
+    }
+  };
+  
+  // 시그널 전송 함수
+  const sendSignal = (type, data, targetId = null) => {
+    if (!user || !isConnected) return;
+
+    console.log(`[sendSignal] ${type} ${targetId ? `to ${targetId}` : ""}`, data);
+
+    stompClientRef.current?.publish({
+      destination: "/pub/signal",
+      body: JSON.stringify({
+        type,
+        roomId,
+        senderId: user.id,
+        senderNickname: user.nickname,
+        targetId,
+        data,
+      }),
+    });
+  };
+
+  const removePeer = (peerId) => {
+    const pc = peerConnections.current[peerId];
+    if (pc) {
+      console.log(`[removePeer] 피어 연결 종료 및 제거 - peerId: ${peerId}`);
+      pc.close();
+      delete peerConnections.current[peerId];
+      setRemoteStreams((prev) => {
+        const next = prev.filter((s) => s.peerId !== peerId);
+        if (next.length === 0) {
+          console.log("[removePeer] 모든 피어 연결 종료");
+        } else {
+          console.log("[removePeer] 피어 연결 종료", next);
+        }
+        return next;
+      });
+    } else {
+      console.warn(`[removePeer] 피어 연결이 존재하지 않음 - peerId: ${peerId}`);
+    }
+  };
+
+  const createPeerConnection = async (peerId, nickname, isInitiator) => {
+    if (peerConnections.current[peerId]) {
+      console.warn(`[createPeerConnection] 이미 연결이 존재함 : ${peerId}`);
+      return;
+    }
+
+    const pc = new RTCPeerConnection({
+      iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
+    });
+
+    peerConnections.current[peerId] = pc;
+
+    console.log(`[createPeerConnection] → ${peerId} (${nickname}), initiator: ${isInitiator}`);
+
+    pc.onicecandidate = (event) => {
+      if (event.candidate) {
+        sendSignal("ice", event.candidate, peerId);
+      }
+    };
+
+    pc.ontrack = (event) => {
+      const stream = event.streams?.[0];
+      if (!stream) return;
+      setRemoteStreams((prev) => {
+        const filtered = prev.filter((s) => s.peerId !== peerId);
+        return [...filtered, { peerId, stream, nickname }];
+      });
+    };
+
+    localStream.getTracks().forEach((track) => {
+      pc.addTrack(track, localStream);
+    });
+
+    if (isInitiator) {
+      try {
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+        sendSignal("offer", offer, peerId);
+      } catch (e) {
+        console.error(`[createPeerConnection] offer 생성 실패: ${peerId}`, e);
+      }
+    }
+  };
+
+  const handleOffer = async (peerId, nickname, offer) => {
+    const existing = peerConnections.current[peerId];
+    if (existing && existing.signalingState !== "stable") {
+      console.warn(`[handleOffer] ${peerId} 이미 stable 아님, offer 무시`);
+      return;
+    }
+
+    removePeer(peerId);
+    console.log(`[handleOffer] from: ${peerId} (${nickname})`);
+
+    await createPeerConnection(peerId, nickname, false);
+    const newPc = peerConnections.current[peerId];
+
+    try {
+      await newPc.setRemoteDescription(new RTCSessionDescription(offer));
+      const answer = await newPc.createAnswer();
+      await newPc.setLocalDescription(answer);
+      sendSignal("answer", answer, peerId);
+
+      if (pendingCandidates.current[peerId]) {
+        for (const c of pendingCandidates.current[peerId]) {
+          await newPc.addIceCandidate(new RTCIceCandidate(c));
+        }
+        delete pendingCandidates.current[peerId];
+      }
+    } catch (err) {
+      console.error(`[handleOffer] 처리 실패 (${peerId}):`, err);
+      removePeer(peerId);
+    }
+  };
+
+  const handleAnswer = async (peerId, answer) => {
+    console.log(`[handleAnswer] from: ${peerId}`);
+    const pc = peerConnections.current[peerId];
+    if (!pc) return;
+
+    if (pc.signalingState !== "have-local-offer") {
+      console.warn(`[handleAnswer] ${peerId} 상태가 ${pc.signalingState}, answer 무시`);
+      return;
+    }
+
+    try {
+      await pc.setRemoteDescription(new RTCSessionDescription(answer));
+      if (pendingCandidates.current[peerId]) {
+        for (const c of pendingCandidates.current[peerId]) {
+          await pc.addIceCandidate(new RTCIceCandidate(c));
+        }
+        delete pendingCandidates.current[peerId];
+      }
+    } catch (err) {
+      console.error(`[handleAnswer] setRemoteDescription 실패 (${peerId}):`, err);
+      removePeer(peerId);
+    }
+  };
+
+  const handleIce = async (peerId, candidate) => {
+    console.log(`[handleIce] from: ${peerId}`, candidate);
+    const pc = peerConnections.current[peerId];
+
+    if (pc?.remoteDescription) {
+      await pc.addIceCandidate(new RTCIceCandidate(candidate));
+    } else {
+      pendingCandidates.current[peerId] ??= [];
+      pendingCandidates.current[peerId].push(candidate);
+    }
+  };
+
+  useEffect(() => {
+    if (!user || !roomId || !isConnected) return;
+    const client = stompClientRef.current;
+    if (!client) return;
+
+    let userSubscription;
+    let roomSubscription;
+
+    const handleSignal = async (msg) => {
+      const { type, senderId, senderNickname, targetId, data } = JSON.parse(msg.body);
+      if (senderId === user.id) return;
+      // 1:1 메시지는 targetId 필터링
+      if (["offer", "answer", "ice"].includes(type)) {
+        if (targetId !== user.id) return;
+      }
+
+      switch (type) {
+        case "offer":
+          await handleOffer(senderId, senderNickname, data);
+          break;
+        case "answer":
+          await handleAnswer(senderId, data);
+          break;
+        case "ice":
+          await handleIce(senderId, data);
+          break;
+        case "join":
+          if (!peerConnections.current[senderId]) {
+            await createPeerConnection(senderId, senderNickname, false); // 내가 initiator
+          }
+          break;
+        case "leave":
+          console.log(`[handleSignal] leave: ${senderId}`);
+          removePeer(senderId);
+          break;
+        default:
+          break;
+      }
+    };
+
+    userSubscription = client.subscribe(`/sub/user/${user.id}`, handleSignal);
+    roomSubscription = client.subscribe(`/sub/room/${roomId}`, handleSignal);
+
+    fetchExistingUsersAndConnect();
+    sendSignal("join", {});
+
+    return () => {
+      console.log("[WebRTC Cleanup] 컴포넌트 언마운트 or 의존성 변경");
+
+      if (user && isConnected) {
+        console.log("[WebRTC Cleanup] leave 시그널 전송");
+
+        sendSignal("leave", {});
+      }
+      console.log("[WebRTC Cleanup] stomp 구독 해제");
+
+      userSubscription?.unsubscribe();
+      roomSubscription?.unsubscribe();
+    };
+  }, [user, roomId, stompClientRef, isConnected]);
+
+  useEffect(() => {
+    return () => {
+      Object.keys(peerConnections.current).forEach((peerId) => {
+        removePeer(peerId);
+      });
+    };
+  }, []);
+
+  return { remoteStreams };
+};

--- a/frontend/src/pages/rooms/StudyRoom.js
+++ b/frontend/src/pages/rooms/StudyRoom.js
@@ -1,0 +1,102 @@
+import React, { useState, useCallback, useRef, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import useCurrentUser from "../../hooks/useCurrentUser";
+import { useWebRTC } from "../../hooks/useWebRTC";
+import { useChat } from "../../hooks/useChat";
+import { apiGet, apiPost, extractErrorInfo } from "../../utils/api";
+import { useStompClient } from "../../hooks/useStompClient";
+
+import styles from "./StudyRoom.module.css";
+import ChatSection from "../../components/Chat/ChatSection";
+import VideoSection from "../../components/Video/VideoSection";
+import { toast } from "react-toastify";
+
+const StudyRoom = () => {
+  const navigate = useNavigate();
+  const user = useCurrentUser();
+  const { roomId } = useParams();
+  const myNickname = user?.nickname || "익명";
+
+  const [room, setRoom] = useState(null);
+  const [localStream, setLocalStream] = useState(null);
+  const isReadyForWebRTC = !!user && !!localStream;
+
+  const { stompClientRef, isConnected } = useStompClient();
+
+
+  useEffect(() => {
+    if (!roomId) return; 
+
+    apiGet(`/rooms/${roomId}`)
+      .then(setRoom)
+      .catch((err) => {
+        console.error("방 정보 조회 실패", err);
+        toast.error("방 정보 조회 실패");
+        navigate("/rooms");
+      });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (!roomId) return;
+
+      apiPost(`rooms/${roomId}/exit`).catch((err) => {
+         const { status, data } = extractErrorInfo(err);
+        if (status === 409) {
+          console.warn("이미 퇴장된 사용자여서 무시.", data);
+        } else {
+          toast.error("퇴장 중 오류가 발생했습니다. 새로고침 해주세요.");
+        }
+      });
+    };
+  }, [roomId, isConnected]);
+
+  useEffect(() => {
+    const initStream = async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+          audio: false,
+        });
+        setLocalStream(stream);
+      } catch (err) {
+        console.error("로컬 스트림 획득 실패", err);
+      }
+    };
+
+    initStream();
+  }, []);
+
+  const { remoteStreams } = useWebRTC(
+    roomId,
+    isReadyForWebRTC ? user : null,
+    isReadyForWebRTC ? localStream : null,
+    stompClientRef,
+    isConnected
+  );
+
+  const {
+    chatMessages,
+    chatInputRef,
+    handleSendChat
+  } = useChat(roomId, user, stompClientRef, isConnected );
+
+  return (
+    <div className={styles.roomLayout}>
+      <VideoSection
+        myStream={localStream}
+        others={remoteStreams}
+        myNickname={myNickname}
+        room={room}
+      />
+      <ChatSection
+        chatMessages={chatMessages}
+        chatInput={chatInputRef}
+        handleSendChat={handleSendChat}
+      />
+    </div>
+  );
+};
+
+export default StudyRoom;

--- a/frontend/src/pages/rooms/StudyRoom.module.css
+++ b/frontend/src/pages/rooms/StudyRoom.module.css
@@ -1,0 +1,11 @@
+.roomLayout {
+  display: flex;
+  height: 100%;
+  gap: 20px;
+}
+
+@media (max-width: 1000px) {
+  .roomLayout {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/pages/rooms/StudyRoomList.module.css
+++ b/frontend/src/pages/rooms/StudyRoomList.module.css
@@ -1,16 +1,45 @@
 .wrapper {
   padding: 20px;
   width: 100%;
-  height: 100%;
+  min-height: calc(100vh - 110px);
   margin: 0 auto;
-  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+  border-radius: 10px;
 }
 
-.header {
+.searchContainer {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 30px;
+  position: relative;
+  max-width: 100%;
+  margin: 0 20px;
+}
+
+.searchInput {
+  flex: 1;
+  padding: 12px 40px 12px 12px;
+  font-size: 14px;
+  border: 2px solid #1c4454;
+  border-radius: 4px;
+  outline: none;
+  color: #333;
+}
+
+.searchInput::placeholder {
+  color: #aaa;
+}
+
+.searchBtn {
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
 }
 
 .title {
@@ -20,40 +49,101 @@
 }
 
 .createBtn {
-  background-color: #666;
+  position: fixed;
+  bottom: 40px;
+  right: 40px;
+  background-color: #b96852;
   color: white;
-  padding: 10px 20px;
+  padding: 14px 20px;
   border: none;
-  border-radius: 6px;
+  border-radius: 50px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 16px;
+  font-weight: bold;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  z-index: 999;
+  transition: background-color 0.2s;
 }
 
 .createBtn:hover {
-  background-color: #444;
+  background-color: #d4431b;
 }
 
 .roomList {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  /* gap: 10px; */
+  margin-top: 20px;
+  margin: 20px;
+}
+
+.roomListHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  font-weight: bold;
+  /* background-color: #f0f8ff; */
+  border-bottom: 1px solid #ddd;
+}
+
+.roomListRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 25px 0;
+  border-bottom: 1px solid #ddd;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.roomInfoWrapper {
+  display: flex;
+  gap: 30px;
+  align-items: center;
+  justify-content: flex-end; /* 우측 정렬 */
+  flex: 1;
+  padding: 0 10px;
+}
+
+.roomListRow:hover {
+  background-color: #f2f2f2;
+}
+
+/* 칸들 스타일 */
+.roomTitleCell {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start; /* 제목은 왼쪽 정렬 */
+  padding: 0 10px;
+}
+
+.roomTimeCell,
+.roomInfoCell {
+  font-size: 14px;
+  color: #555;
+  display: flex;
+  align-items: center;
 }
 
 .roomCard {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 30px;
-  border: 1px solid #ddd;
-  border-radius: 10px;
+  padding: 15px 10px;
+  /* border: 1px solid #ddd; */
+  border-bottom: 1px solid #ddd;
+
+  /* border-radius: 10px; */
   background-color: #fff;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.04);
+  /* box-shadow: 0 2px 5px rgba(0, 0, 0, 0.04); */
   transition: all 0.2s ease;
 }
 
 .roomCard:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
+  background-color: #e8f5ff;
 }
 
 /* 제목+인원 묶기 */
@@ -156,7 +246,7 @@
 
 .modal {
   background: white;
-  padding: 30px;
+  padding: 20px;
   border-radius: 10px;
   width: 320px;
   display: flex;
@@ -175,16 +265,17 @@
 }
 
 .modalTitle {
-  font-size: 18px;
+  font-size: 25px;
   font-weight: 700;
   margin-bottom: 10px;
-  color: #222;
+
+  color: skyblue;
   text-align: center;
 }
 
 .label {
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 800;
   margin: 5px 0;
   color: #444;
 }
@@ -224,4 +315,54 @@
   border: none;
   border-radius: 6px;
   cursor: pointer;
+}
+
+.loadingWrapper {
+  width: 100%;
+  height: 400px; /* 또는 화면 높이에 맞춰도 되고 */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 30px;
+  gap: 8px;
+}
+
+.pageBtn,
+.pageNumber {
+  all: unset; /* 버튼 기본 스타일 제거 */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+  background-color: #f1f3f5;
+}
+
+.pageBtn:hover {
+  background-color: #dbe2e8;
+}
+
+.pageNumber {
+  background-color: #f8f9fa;
+}
+
+.pageNumber:hover {
+  background-color: #e2e6ea;
+}
+
+.pageNumber.active {
+  background-color: #b96852;
+  color: white;
 }


### PR DESCRIPTION
## 요약
스터디룸 내 화상 연결(WebRTC), 채팅(STOMP), UI 구성 및 전역 훅 구조화를 포함한 스터디룸 기능 구현 완료

<br><br>
## 작업 내용
- useWebRTC, useChat, useStompClient 등 커스텀 훅 작성 및 구조화
- WebRTC 기반 peer 연결 및 해제 로직 구현
- STOMP 기반 단체 채팅 송수신 구현
- 입장/퇴장 시 leave/join 시그널 처리 및 RedisMessageSubscriber 리팩터링
  - 입장, 퇴장 메시지 생기도록 추가
  
### StudyRoom
- StudyRoom 페이지 구현
- ChatSection, VideoSection 컴포넌트화 및 스타일링 적용
- 스터디룸 목록 조회/생성 API 연동

### Backend
- SignalingMessageDTO에 targetId 필드 추가
- 채팅 구독경로 /sub/room/chat/룸아이디 로 변경

<br><br>

## 참고 사항
- WebRTC와 Chat을 따로두어 1대1 채팅으로도 확장 가능할 것 같음
- 크롬탭, 크롬시크릿으로 2개 유저만 테스트 해보다가 사파리로 3명 추가될 때 오퍼/엔서 교환에서 에러가 상당했는데 targetId를 추가하여 전체 브로드캐스트 되는게 아니라 1대1로 교환하도록 변경하여 해결됨

- StudyRoom 내부 스타일링 개선 필요
  - 룸정보나, 비디오컨트롤러바, 채팅(색상이나, 나와 다른사람들 위치 분리)

- 현재는, StudyRoom에서 뒤로가기나 다른페이지 이동 -> Unmount시에만 방나가기가 적용됨.
- 탭닫기, 브라우저 종료 등은 인식X -> 시도했으나 새로고침까지 방나가기가 처리되어 적용취소함. 추후 개선필요
<br><br>

## 관련 이슈

- Close #67 

<br><br>
