### PR TITLE
feat: 플래너(Plan) 도메인 기본 기능 구현

### DIFF
--- a/backend/src/main/java/com/swu/controller/PlanController.java
+++ b/backend/src/main/java/com/swu/controller/PlanController.java
@@ -1,0 +1,85 @@
+package com.swu.controller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.swu.auth.entity.CustomUserDetails;
+import com.swu.domain.plan.dto.PlanRequest;
+import com.swu.domain.plan.dto.PlanResponse;
+import com.swu.domain.plan.service.PlanService;
+import com.swu.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/plans")
+@RequiredArgsConstructor
+@Tag(name = "Plan", description = "플래너(투두리스트) 관련 API")
+public class PlanController {
+    
+    private final PlanService planService;
+
+    @Operation(summary = "플랜 생성", description = "사용자의 새로운 할 일을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<PlanResponse>> createPlan(
+            @RequestBody @Valid PlanRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PlanResponse response = planService.createPlan(request, userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("플랜 생성 성공", response));
+    }
+
+    @Operation(summary = "플랜 조회", description = "요청한 날짜 기준으로 사용자의 할 일을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PlanResponse>>> getPlansByDate(
+            @RequestParam LocalDate date,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<PlanResponse> responses = planService.getPlansByDate(date, userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("플랜 조회 성공", responses));
+    }
+
+    @Operation(summary = "월별 플랜 조회", description = "요청한 연도/월 기준으로 사용자의 할 일을 조회합니다.")
+    @GetMapping("/month")
+    public ResponseEntity<ApiResponse<List<PlanResponse>>> getPlansByMonth(
+            @RequestParam int year,
+            @RequestParam int month,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        List<PlanResponse> responses = planService.getPlansByMonth(year, month, userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("월별 플랜 조회 성공", responses));
+    }
+
+    @Operation(summary = "특정 플랜 수정", description = "특정 플랜을 수정합니다.")
+    @PatchMapping("/{planId}")
+    public ResponseEntity<ApiResponse<PlanResponse>> updatePlan(
+            @PathVariable Long planId,
+            @RequestBody @Valid PlanRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        PlanResponse response = planService.updatePlan(planId, request, userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("플랜 수정 성공", response));
+        }
+
+    @Operation(summary = "플랜 삭제", description = "사용자의 플랜을 삭제합니다.")
+    @DeleteMapping("/{planId}")
+    public ResponseEntity<ApiResponse<Void>> deletePlan(
+            @PathVariable Long planId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        planService.deletePlan(planId, userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("플랜 삭제 성공", null));
+    }   
+}

--- a/backend/src/main/java/com/swu/domain/plan/dto/PlanRequest.java
+++ b/backend/src/main/java/com/swu/domain/plan/dto/PlanRequest.java
@@ -1,0 +1,20 @@
+package com.swu.domain.plan.dto;
+
+import com.swu.domain.plan.entity.Plan.Priority;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record PlanRequest(
+        @NotBlank(message = "내용은 필수입니다.")
+        String content,
+
+        @NotNull(message = "계획일자는 필수입니다.")
+        @FutureOrPresent(message = "계획일자는 오늘 또는 미래여야 합니다.")
+        LocalDate planDate,
+
+        @NotNull(message = "중요도를 선택해주세요.")
+        Priority priority
+) {}

--- a/backend/src/main/java/com/swu/domain/plan/dto/PlanRequest.java
+++ b/backend/src/main/java/com/swu/domain/plan/dto/PlanRequest.java
@@ -16,5 +16,8 @@ public record PlanRequest(
         LocalDate planDate,
 
         @NotNull(message = "중요도를 선택해주세요.")
-        Priority priority
+        Priority priority,
+
+        @NotNull(message = "완료 여부는 필수입니다.")
+        Boolean isCompleted
 ) {}

--- a/backend/src/main/java/com/swu/domain/plan/dto/PlanResponse.java
+++ b/backend/src/main/java/com/swu/domain/plan/dto/PlanResponse.java
@@ -1,5 +1,6 @@
 package com.swu.domain.plan.dto;
 
+import com.swu.domain.plan.entity.Plan;
 import com.swu.domain.plan.entity.Plan.Priority;
 
 import java.time.LocalDate;
@@ -10,4 +11,14 @@ public record PlanResponse(
         LocalDate planDate,
         Priority priority,
         boolean isCompleted
-) {}
+) {
+    public static PlanResponse from(Plan plan) {
+        return new PlanResponse(
+                plan.getId(),
+                plan.getContent(),
+                plan.getPlanDate(),
+                plan.getPriority(),
+                plan.isCompleted()
+        );
+    }
+}

--- a/backend/src/main/java/com/swu/domain/plan/dto/PlanResponse.java
+++ b/backend/src/main/java/com/swu/domain/plan/dto/PlanResponse.java
@@ -1,0 +1,13 @@
+package com.swu.domain.plan.dto;
+
+import com.swu.domain.plan.entity.Plan.Priority;
+
+import java.time.LocalDate;
+
+public record PlanResponse(
+        Long id,
+        String content,
+        LocalDate planDate,
+        Priority priority,
+        boolean isCompleted
+) {}

--- a/backend/src/main/java/com/swu/domain/plan/entity/Plan.java
+++ b/backend/src/main/java/com/swu/domain/plan/entity/Plan.java
@@ -41,4 +41,11 @@ public class Plan {
     public enum Priority {
         LOW, MEDIUM, HIGH
     }
+
+    public void update(String content, LocalDate planDate, Priority priority, boolean isCompleted) {
+        this.content = content;
+        this.planDate = planDate;
+        this.priority = priority;
+        this.isCompleted = isCompleted;
+    }
 }

--- a/backend/src/main/java/com/swu/domain/plan/entity/Plan.java
+++ b/backend/src/main/java/com/swu/domain/plan/entity/Plan.java
@@ -23,8 +23,11 @@ public class Plan {
     @Column(nullable = false, length = 255)
     private String content;
 
-    // 오늘 or 특정 날짜
     private LocalDate planDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Priority priority;
 
     private boolean isCompleted;
 
@@ -34,4 +37,8 @@ public class Plan {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public enum Priority {
+        LOW, MEDIUM, HIGH
+    }
 }

--- a/backend/src/main/java/com/swu/domain/plan/exception/PlanNotFoundException.java
+++ b/backend/src/main/java/com/swu/domain/plan/exception/PlanNotFoundException.java
@@ -1,0 +1,7 @@
+package com.swu.domain.plan.exception;
+
+public class PlanNotFoundException extends RuntimeException {
+    public PlanNotFoundException() {
+        super("해당 플랜을 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/swu/domain/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/swu/domain/plan/repository/PlanRepository.java
@@ -1,8 +1,24 @@
 package com.swu.domain.plan.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.swu.domain.plan.entity.Plan;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    // 특정 사용자, 특정 날짜 기준 정렬 (우선순위 기준)
+    List<Plan> findByUserIdAndPlanDateOrderByPriorityDesc(Long userId, LocalDate planDate);
+
+    // 특정 사용자, 특정 날짜 범위 기준 정렬
+    List<Plan> findByUserIdAndPlanDateBetweenOrderByPlanDateAsc(Long userId, LocalDate start, LocalDate end);
+
+    // 특정 사용자 소유의 Plan 단건 조회 (권한 보호)
+    Optional<Plan> findByIdAndUserId(Long planId, Long userId);
+
+    // 필요 시: 전체 Plan 날짜별 정렬 (사용자 전용)
+    List<Plan> findByUserIdOrderByPlanDateDesc(Long userId);
 }

--- a/backend/src/main/java/com/swu/domain/plan/service/PlanService.java
+++ b/backend/src/main/java/com/swu/domain/plan/service/PlanService.java
@@ -1,0 +1,90 @@
+package com.swu.domain.plan.service;
+
+import com.swu.domain.plan.dto.PlanRequest;
+import com.swu.domain.plan.dto.PlanResponse;
+import com.swu.domain.plan.entity.Plan;
+import com.swu.domain.plan.repository.PlanRepository;
+import com.swu.domain.plan.exception.PlanNotFoundException;
+import com.swu.domain.user.entity.User;
+import com.swu.domain.user.exception.UserNotFoundException;
+import com.swu.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanRepository planRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public PlanResponse createPlan(PlanRequest request, Long userId) {
+        log.info("유저 ID {}의 플랜 생성 요청: {}", userId, request);
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Plan plan = Plan.builder()
+                .user(user)
+                .content(request.content())
+                .planDate(request.planDate())
+                .priority(request.priority())
+                .isCompleted(false)
+                .build();
+
+        planRepository.save(plan);
+        return PlanResponse.from(plan);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlanResponse> getPlansByDate(LocalDate date, Long userId) {
+        log.debug("유저 ID {}의 {} 날짜 플랜 조회", userId, date);
+        List<Plan> plans = planRepository.findByUserIdAndPlanDateOrderByPriorityDesc(userId, date);
+        return plans.stream()
+                .map(PlanResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlanResponse> getPlansByMonth(int year, int month, Long userId) {
+        log.debug("유저 ID {}의 {}년 {}월 플랜 조회", userId, year, month);
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        List<Plan> plans = planRepository.findByUserIdAndPlanDateBetweenOrderByPlanDateAsc(userId, start, end);
+        return plans.stream()
+                .map(PlanResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public PlanResponse updatePlan(Long planId, PlanRequest request, Long userId) {
+        log.info("플랜 수정 요청: planId={}, userId={}", planId, userId);
+        Plan plan = planRepository.findByIdAndUserId(planId, userId)
+                .orElseThrow(PlanNotFoundException::new);
+
+        plan.update(
+            request.content(),
+            request.planDate(),
+            request.priority(),
+            request.isCompleted()
+        );
+        return PlanResponse.from(plan);
+    }
+
+    @Transactional
+    public void deletePlan(Long planId, Long userId) {
+        log.info("플랜 삭제 요청: planId={}, userId={}", planId, userId);
+        Plan plan = planRepository.findByIdAndUserId(planId, userId)
+                .orElseThrow(PlanNotFoundException::new);
+        planRepository.delete(plan);
+    }
+}

--- a/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/swu/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.swu.global.exception;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.swu.domain.diary.exception.DiaryAlreadyExistsException;
 import com.swu.domain.diary.exception.DiaryNotFoundException;
+import com.swu.domain.plan.exception.PlanNotFoundException;
 import com.swu.domain.room.exception.AlreadyJoinedRoomException;
 import com.swu.domain.room.exception.NotJoinedRoomException;
 import com.swu.domain.room.exception.RoomFullException;
@@ -145,6 +146,14 @@ public class GlobalExceptionHandler {
         log.warn("DiaryAlreadyExistsException: {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.failure(e.getMessage()));
+    }
+
+    @ExceptionHandler(PlanNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePlanNotFoundException(PlanNotFoundException e) {
+        log.warn("PlanNotFoundException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.failure(e.getMessage()));
     }
 


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용
- Plan Entity에 중요도(Priority) Enum 속성 추가
- PlanRequest / PlanResponse DTO 정의 및 검증 애노테이션 적용
- PlanNotFoundException 정의 
- PlanResponse.from(), Plan.update() 등 정적 메서드 및 엔티티 업데이트 메서드 구성
- PlanController, PlanService, PlanRepository 구현
- 일별 / 월별 조회, 생성, 수정, 삭제 기능 지원
<br><br>

## 참고 사항
📌 API 명세
POST   /api/plans           - 플랜 생성
GET    /api/plans?date=...  - 특정 날짜의 플랜 조회
GET    /api/plans/month     - 월별 플랜 조회 (year, month 파라미터)
PATCH  /api/plans/{id}      - 플랜 수정
DELETE /api/plans/{id}      - 플랜 삭제
<br><br>

## 관련 이슈

- Close #XXX

<br><br>
