### PR TITLE
feat: Refresh Token 관리 및 재발급/로그아웃 기능 구현

### DIFF
--- a/backend/src/main/java/com/swu/auth/controller/TokenController.java
+++ b/backend/src/main/java/com/swu/auth/controller/TokenController.java
@@ -1,103 +1,30 @@
 package com.swu.auth.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.swu.auth.jwt.JWTUtil;
+import com.swu.auth.service.TokenService;
 import com.swu.global.response.ApiResponse;
 
-import io.jsonwebtoken.ExpiredJwtException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-/**
- * - Access/Refresh 토큰 재발급 컨트롤러
- * - 클라이언트가 refresh 토큰을 쿠키에 담아 요청하면
- * - 새로운 access/refresh 토큰을 재발급해서 응답에 포함
- * - access 토큰은 응답 헤더(Authorization), refresh 토큰은 HttpOnly 쿠키로 반환
- * - refresh 토큰의 유효성/타입을 검증하고, rotate 방식 적용
- */
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 @Tag(name = "Token", description = "토큰 관련 API")
 public class TokenController {
 
-    private final JWTUtil jwtUtil;
+    private final TokenService tokenService;
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "Refresh 토큰을 검증하여 새로운 Access/Refresh 토큰을 재발급합니다.")
     public ResponseEntity<ApiResponse<Void>> reissue(HttpServletRequest request, HttpServletResponse response) {
-
-        // 1. 쿠키에서 refresh 토큰 꺼내기
-        String refresh = null;
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (cookie.getName().equals("refresh")) {
-                    refresh = cookie.getValue();
-                }
-            }
-        }
-
-        if (refresh == null || refresh.isBlank()) {
-            log.warn("refresh token 누락");
-            return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.failure("refresh token null"));
-        }
-
-        // 2. 만료 여부 검사
-        try {
-            jwtUtil.isExpired(refresh);
-        } catch (ExpiredJwtException e) {
-            log.warn("refresh token 만료됨");
-            return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.failure("refresh token expired"));
-        } 
-
-        // 3. 토큰 타입 확인
-        String category = jwtUtil.getCategory(refresh);
-        if (!"refresh".equals(category)) {
-            log.warn("잘못된 토큰 타입: {} (expect: refresh)", category);
-            return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ApiResponse.failure("invalid token type"));
-        }
-
-        // 4. 새로운 access/refresh 토큰 생성
-        Long id = (long) jwtUtil.getId(refresh);
-        String role = jwtUtil.getRole(refresh);
-        String newAccess = jwtUtil.createJwt("access", role, id, 600000L);
-        String newRefresh = jwtUtil.createJwt("refresh", role, id, 86400000L);
-
-        // 5. 쿠키와 헤더에 access/refresh 토큰 추가 (Refresh Rotate)
-        response.setHeader("Authorization", "Bearer " + newAccess);
-        response.addCookie(createCookie("refresh", newRefresh));
-
-        log.info("access/refresh token 재발급 완료 - userId: {}", id);
-
-        return ResponseEntity.ok(ApiResponse.success("access/refresh token 재발급 완료", null));
-    }
-
-    private Cookie createCookie(String key, String value) {
-
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(24*60*60);
-        //cookie.setSecure(true);
-        //cookie.setPath("/");
-        cookie.setHttpOnly(true);
-    
-        return cookie;
+        return tokenService.reissueToken(request, response);
     }
 }

--- a/backend/src/main/java/com/swu/auth/controller/TokenController.java
+++ b/backend/src/main/java/com/swu/auth/controller/TokenController.java
@@ -1,0 +1,103 @@
+package com.swu.auth.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.swu.auth.jwt.JWTUtil;
+import com.swu.global.response.ApiResponse;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * - Access/Refresh 토큰 재발급 컨트롤러
+ * - 클라이언트가 refresh 토큰을 쿠키에 담아 요청하면
+ * - 새로운 access/refresh 토큰을 재발급해서 응답에 포함
+ * - access 토큰은 응답 헤더(Authorization), refresh 토큰은 HttpOnly 쿠키로 반환
+ * - refresh 토큰의 유효성/타입을 검증하고, rotate 방식 적용
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Token", description = "토큰 관련 API")
+public class TokenController {
+
+    private final JWTUtil jwtUtil;
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "Refresh 토큰을 검증하여 새로운 Access/Refresh 토큰을 재발급합니다.")
+    public ResponseEntity<ApiResponse<Void>> reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        // 1. 쿠키에서 refresh 토큰 꺼내기
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                }
+            }
+        }
+
+        if (refresh == null || refresh.isBlank()) {
+            log.warn("refresh token 누락");
+            return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.failure("refresh token null"));
+        }
+
+        // 2. 만료 여부 검사
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            log.warn("refresh token 만료됨");
+            return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.failure("refresh token expired"));
+        } 
+
+        // 3. 토큰 타입 확인
+        String category = jwtUtil.getCategory(refresh);
+        if (!"refresh".equals(category)) {
+            log.warn("잘못된 토큰 타입: {} (expect: refresh)", category);
+            return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.failure("invalid token type"));
+        }
+
+        // 4. 새로운 access/refresh 토큰 생성
+        Long id = (long) jwtUtil.getId(refresh);
+        String role = jwtUtil.getRole(refresh);
+        String newAccess = jwtUtil.createJwt("access", role, id, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", role, id, 86400000L);
+
+        // 5. 쿠키와 헤더에 access/refresh 토큰 추가 (Refresh Rotate)
+        response.setHeader("Authorization", "Bearer " + newAccess);
+        response.addCookie(createCookie("refresh", newRefresh));
+
+        log.info("access/refresh token 재발급 완료 - userId: {}", id);
+
+        return ResponseEntity.ok(ApiResponse.success("access/refresh token 재발급 완료", null));
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        //cookie.setSecure(true);
+        //cookie.setPath("/");
+        cookie.setHttpOnly(true);
+    
+        return cookie;
+    }
+}

--- a/backend/src/main/java/com/swu/auth/jwt/CustomLogoutFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/CustomLogoutFilter.java
@@ -1,0 +1,125 @@
+package com.swu.auth.jwt;
+
+import java.io.IOException;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.GenericFilterBean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swu.global.response.ApiResponse;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Refresh 토큰 기반 로그아웃 처리 필터
+ * - 요청 URI가 "/logout"이고 POST 방식일 경우 동작
+ * - 쿠키에서 refresh 토큰을 추출하여 검증
+ * - Redis에서 해당 토큰 삭제 (단일 토큰 관리 방식 기준)
+ * - 클라이언트 쿠키 제거 및 성공 응답 반환
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean{
+
+    private final JWTUtil jwtUtil;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        // 1. URI 및 메서드 확인
+        if (!request.getRequestURI().matches("^/api/auth/logout$") || !request.getMethod().equalsIgnoreCase("POST")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        log.info("로그아웃 요청 수신");
+
+        // 2. 쿠키에서 Refresh 토큰 추출
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refresh".equals(cookie.getName())) {
+                    refresh = cookie.getValue();
+                }
+            }
+        }
+     
+        if (refresh == null || refresh.isBlank()) {
+            log.warn("Refresh 토큰 없음");
+
+            sendJsonError(response, HttpStatus.BAD_REQUEST, "refresh token is missing");
+            return;
+        }
+
+        // 3. 만료 확인
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 refresh token으로 로그아웃 시도");
+
+            sendJsonError(response, HttpStatus.BAD_REQUEST, "refresh token is expired");
+            return;
+        }
+
+        // 4. 토큰 타입 확인
+        String category = jwtUtil.getCategory(refresh);
+        if (!"refresh".equals(category)) {
+            log.warn("refresh 토큰 아님. category: {}", category);
+
+            sendJsonError(response, HttpStatus.BAD_REQUEST, "invalid token type");
+            return;
+        }
+
+        // 5. Redis에서 해당 유저의 토큰 삭제
+        Long userId = (long) jwtUtil.getId(refresh);
+        String redisKey = "refresh:user:" + userId;
+        redisTemplate.delete(redisKey);        
+
+        log.info("Redis에서 refresh 토큰 삭제 완료 - userId: {}", userId);
+
+        // 6. 쿠키 삭제
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        // 7. 성공 응답 반환
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<Void> apiResponse = ApiResponse.success("로그아웃 완료", null);
+        String responseBody = new ObjectMapper().writeValueAsString(apiResponse);
+        response.getWriter().write(responseBody);
+
+        log.info("로그아웃 처리 완료 - userId: {}", userId);
+    }
+    
+      private void sendJsonError(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<Void> apiResponse = ApiResponse.failure(message);
+        String responseBody = new ObjectMapper().writeValueAsString(apiResponse);
+        response.getWriter().write(responseBody);
+    }
+}

--- a/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
@@ -17,8 +17,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
@@ -2,11 +2,16 @@ package com.swu.auth.jwt;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swu.auth.entity.CustomUserDetails;
 import com.swu.domain.user.entity.Role;
 import com.swu.domain.user.entity.User;
+import com.swu.global.response.ApiResponse;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -34,58 +39,90 @@ public class JWTFilter extends OncePerRequestFilter{
         String path = request.getRequestURI();
         
         if (path.startsWith("/api/auth")
-                || path.startsWith("/ws")
                 || path.startsWith("/v3/api-docs")
                 || path.startsWith("/swagger-ui")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String authorization = request.getHeader("Authorization");
-
-        if (authorization == null || !authorization.startsWith("Bearer")) {
+        // 헤더에서 Authorization키에 담긴 토큰을 꺼내기
+        String accessToken = request.getHeader("Authorization");
+        
+        // 토큰이 없거나 Bearer로 시작하지 않으면 필터 체인 진행
+        if (accessToken == null || !accessToken.startsWith("Bearer")) {
             log.warn("토큰이 없거나 Bearer로 시작하지 않음");
             filterChain.doFilter(request, response);
             return;
         }
 
-        log.debug("Authorization header found");
-
         // Bearer 부분 제거 후 순수 토큰 획득
-        String token = authorization.split(" ")[1];
+        String token = accessToken.split(" ")[1];
 
         // 토큰 소멸 시간 검증
-        if (jwtUtil.isExpired(token)) {
-            log.warn("토큰 만료됨");
-            filterChain.doFilter(request, response);
-            return;
+        try {
+            jwtUtil.isExpired(token);
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 Access Token - IP: {}, Path: {}", request.getRemoteAddr(), request.getRequestURI());
+
+            // 1. 응답 상태코드 설정
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+            // 2. 응답 헤더 설정
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+
+            // 3. 응답 바디 구성
+            ApiResponse<Void> apiResponse = ApiResponse.failure("Access token expired");
+            String responseBody = new ObjectMapper().writeValueAsString(apiResponse);
+            response.getWriter().write(responseBody);
+
+            return; 
         }
 
-        String nickname = jwtUtil.getNickname(token);
-        String role = jwtUtil.getRole(token);
+        // 토큰이 access인지 확인
+        String category = jwtUtil.getCategory(token);
+
+        if (!category.equals("Authorization")) {
+            log.warn("Access 토큰 아님 - category: {}, Path: {}", category, path);
+
+            // 1. 응답 상태코드 설정
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+            // 2. 응답 헤더 설정
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+
+            // 3. 응답 바디 구성
+            ApiResponse<Void> apiResponse = ApiResponse.failure("Invalid access token");
+            String responseBody = new ObjectMapper().writeValueAsString(apiResponse);
+            response.getWriter().write(responseBody);
+
+            return; 
+        }
+
+        // 토큰에서 사용자 정보 가져오기
         Integer id = jwtUtil.getId(token);
+        String role = jwtUtil.getRole(token);
 
         Role roleType;
         roleType = Role.valueOf(role);
 
-        //userEntity를 생성하여 값 set
+        // UserEntity를 생성하여 값 set
         User user = User.builder()
                 .id((long) id)
-                .nickname(nickname)
-                .password("temppassword")
                 .role(roleType)
                 .build();
 
-        //UserDetails에 회원 정보 객체 담기
+        // UserDetails에 회원 정보 객체 담기
         CustomUserDetails customUserDetails = new CustomUserDetails(user);
 
-        //스프링 시큐리티 인증 토큰 생성
+        // 스프링 시큐리티 인증 토큰 생성
         Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
 
-        //세션에 사용자 등록
+        // 세션에 사용자 등록
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
-        log.info(id + "번 유저 인증 완료");
+        log.info("인증 완료 - userId: {}, role: {}", id, role);
         filterChain.doFilter(request, response);
     }
 }

--- a/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
@@ -82,7 +82,7 @@ public class JWTFilter extends OncePerRequestFilter{
         // 토큰이 access인지 확인
         String category = jwtUtil.getCategory(token);
 
-        if (!category.equals("Authorization")) {
+        if (!category.equals("access")) {
             log.warn("Access 토큰 아님 - category: {}, Path: {}", category, path);
 
             // 1. 응답 상태코드 설정

--- a/backend/src/main/java/com/swu/auth/jwt/JWTUtil.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTUtil.java
@@ -20,15 +20,6 @@ public class JWTUtil {
         this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
     }
 
-    public String getNickname(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .get("nickname", String.class);
-    }
-
     public Integer getId(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(secretKey)
@@ -47,6 +38,15 @@ public class JWTUtil {
                 .get("role", String.class);
     }
 
+    public String getCategory(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("category", String.class);
+    }
+
     public Boolean isExpired(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(secretKey)
@@ -57,11 +57,11 @@ public class JWTUtil {
                 .before(new Date());
     }
 
-    public String createJwt (String nickname, String role, Long Id, Long expiredMs) {
+    public String createJwt (String category, String role, Long Id, Long expiredMs) {
         Date now = new Date();
         Date expirationDate = new Date(now.getTime() + expiredMs);
         return Jwts.builder()
-                .claim("nickname", nickname)
+                .claim("category", category)
                 .claim("id", Id)
                 .claim("role", role.replace("ROLE_", ""))
                 .setIssuedAt(new Date(System.currentTimeMillis()))

--- a/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
@@ -143,7 +143,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter{
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24*60*60);
         //cookie.setSecure(true);
-        //cookie.setPath("/");
+        cookie.setPath("/");
         cookie.setHttpOnly(true);
     
         return cookie;

--- a/backend/src/main/java/com/swu/auth/service/TokenService.java
+++ b/backend/src/main/java/com/swu/auth/service/TokenService.java
@@ -104,7 +104,7 @@ public class TokenService {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24 * 60 * 60);
         //cookie.setSecure(true);
-        //cookie.setPath("/");
+        cookie.setPath("/");
         cookie.setHttpOnly(true);
         return cookie;
     }

--- a/backend/src/main/java/com/swu/auth/service/TokenService.java
+++ b/backend/src/main/java/com/swu/auth/service/TokenService.java
@@ -1,0 +1,94 @@
+package com.swu.auth.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.swu.auth.jwt.JWTUtil;
+import com.swu.global.response.ApiResponse;
+
+import io.jsonwebtoken.ExpiredJwtException;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Refresh Token을 검증하고 Access/Refresh Token을 재발급하는 서비스
+ * - Refresh Token 유효성 및 타입 검증
+ * - Rotate 방식 적용 (재발급 시 기존 Refresh는 폐기 전제)
+ * - Access Token은 Authorization 헤더로, Refresh는 HttpOnly 쿠키로 반환
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JWTUtil jwtUtil;
+
+    public ResponseEntity<ApiResponse<Void>> reissueToken(HttpServletRequest request, HttpServletResponse response) {
+
+        // 1. 쿠키에서 refresh 토큰 꺼내기
+        String refresh = extractRefreshToken(request);
+
+        if (refresh == null || refresh.isBlank()) {
+            log.warn("refresh token 누락");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.failure("refresh token null"));
+        }
+
+        // 2. 만료 여부 검사
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            log.warn("refresh token 만료됨");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.failure("refresh token expired"));
+        }
+
+        // 3. 토큰 타입 확인
+        String category = jwtUtil.getCategory(refresh);
+        if (!"refresh".equals(category)) {
+            log.warn("잘못된 토큰 타입: {} (expect: refresh)", category);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.failure("invalid token type"));
+        }
+
+        // 4. 새로운 access/refresh 토큰 생성
+        Long id = (long) jwtUtil.getId(refresh);
+        String role = jwtUtil.getRole(refresh);
+        String newAccess = jwtUtil.createJwt("access", role, id, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", role, id, 86400000L);
+
+        // 5. 쿠키와 헤더에 access/refresh 토큰 추가 (Refresh Rotate)
+        response.setHeader("Authorization", "Bearer " + newAccess);
+        response.addCookie(createCookie("refresh", newRefresh));
+
+        log.info("access/refresh token 재발급 완료 - userId: {}", id);
+        return ResponseEntity.ok(ApiResponse.success("access/refresh token 재발급 완료", null));
+    }
+
+    private String extractRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+
+        for (Cookie cookie : cookies) {
+            if ("refresh".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24 * 60 * 60);
+        //cookie.setSecure(true);
+        //cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+    
+}

--- a/backend/src/main/java/com/swu/config/SecurityConfig.java
+++ b/backend/src/main/java/com/swu/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.swu.config;
 
 import com.swu.auth.handler.CustomAuthenticationEntryPoint;
+import com.swu.auth.jwt.CustomLogoutFilter;
 import com.swu.auth.jwt.JWTFilter;
 import com.swu.auth.jwt.JWTUtil;
 import com.swu.auth.jwt.LoginFilter;
@@ -17,6 +18,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
 @RequiredArgsConstructor
@@ -56,7 +58,8 @@ public class SecurityConfig {
         http
                 .addFilterAt(new LoginFilter(authenticationConfiguration.getAuthenticationManager(), jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new JWTFilter(jwtUtil), LoginFilter.class);
-
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, redisTemplate), LogoutFilter.class);
         http
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/backend/src/main/java/com/swu/config/SecurityConfig.java
+++ b/backend/src/main/java/com/swu/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -24,7 +25,7 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JWTUtil jwtUtil;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint; 
-
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -53,7 +54,7 @@ public class SecurityConfig {
                 .authenticationEntryPoint(customAuthenticationEntryPoint) 
                 );       
         http
-                .addFilterAt(new LoginFilter(authenticationConfiguration.getAuthenticationManager(), jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(new LoginFilter(authenticationConfiguration.getAuthenticationManager(), jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(new JWTFilter(jwtUtil), LoginFilter.class);
 
         http
@@ -61,5 +62,4 @@ public class SecurityConfig {
 
         return http.build();
     }
-
 }


### PR DESCRIPTION
## 요약
JWT 인증 구조에 Refresh Token 관리를 Redis 기반으로 통합하고, Access/Refresh 재발급 및 로그아웃 기능을 구현함.
<br><br>

## 작업 내용
### JWT
- JWT에서 nickname 클레임 제거
- 로그인 성공 시  Refresh Token을 쿠키로 응답에 포함
- JWTFilter에서 access 토큰이 아닌 경우 요청 차단
- JWTFilter에서 access 토큰 만료 시 401 응답 처리

### 토큰 재발급 (`/api/auth/reissue`)
- TokenController, TokenService로 재발급 API 구현
- Refresh Token 만료 및 타입 검증 로직 포함
- Refresh Rotate 방식 적용
- 재발급 시 새로운 Refresh Token을 Redis에 갱신

### Redis 기반 Refresh Token 관리 도입
- 로그인 시 Redis에 유저별 Refresh Token 저장 (key -> refresh:user:{userId)
- 재발급 시 Redis에 저장된 토큰과 비교하여 유효성 검증
- Redis에는 유저당 1개만 Refresh Token만 유지 (덮어쓰기)

### 로그아웃 기능 구현 (`/api/auth/logout`)
- CustomLogoutFilter 구현
- Refresh Token 검증 후 Redis에서 삭제
- 클라이언트 쿠키 삭제 및 JSON 응답 반환

### WebSocket 보안
- StompJwtInterceptor에서 access 토큰 여부 검증 추가

<br><br>

## 참고 사항
- 세션 없이 JWT + Redis로 인증 상태 관리
- Access Token 만료 시 프론트에서 Refresh Token 이용해 재발급 요청 필요
<br><br>

## 관련 이슈

- Close #XXX
<br><br>
