### PR TITLE
feat: 프론트엔드 Refresh 토큰 재발급 및 로그아웃 처리 개선

### DIFF
--- a/frontend/src/components/AuthForm.js
+++ b/frontend/src/components/AuthForm.js
@@ -63,12 +63,13 @@ const AuthForm = () => {
       const res = await axios.post(
         `${process.env.REACT_APP_API_BASE_URL}/auth/login`,
         { email, password },
-        { headers: { "Content-Type": "application/json" } }
+        { headers: { "Content-Type": "application/json" }, withCredentials: true } // refresh token 쿠키 전송
       );
 
       const token = extractTokenFromHeader(res);
       if (token) {
         setToken(token);
+        localStorage.setItem("nickname", res.data.data.nickname);
         navigate("/rooms");
       } else {
         toast.error("로그인 처리 중 문제가 발생했습니다.");

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,6 +1,6 @@
 import styles from "./Header.module.css";
 import { useState, useEffect } from "react";
-import { getNicknameFromToken, removeToken } from "../utils/auth";
+import { removeToken } from "../utils/auth";
 import { FiClock, FiMenu } from "react-icons/fi";
 import MobileSidebar from "./MobileSidebar";
 
@@ -8,11 +8,23 @@ const Header = () => {
   const [studyTime, setStudyTime] = useState("00시간 00분");
   const [currentTime, setCurrentTime] = useState(new Date());
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const nickname = getNicknameFromToken();
+  const nickname = localStorage.getItem("nickname");
 
-  const handleLogout = () => {
-    removeToken();
-    window.location.href = "/";
+  const handleLogout = async () => {
+    try {
+      await fetch(`${process.env.REACT_APP_API_BASE_URL}/auth/logout`, {
+        method: "POST",
+        credentials: "include", // refresh token 쿠키 전송
+      });
+
+      // 서버 로그아웃 성공 후 클라이언트 정리
+      removeToken(); // access token 제거
+      localStorage.removeItem("nickname"); // 닉네임 제거
+      window.location.href = "/";
+    } catch (error) {
+      console.error("로그아웃 실패", error);
+      alert("로그아웃 중 오류가 발생했습니다.");
+    }
   };
 
   // 현재 시간

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -27,32 +27,3 @@ export const extractTokenFromHeader = (res) => {
   const [scheme, token] = authHeader.split(" ");
   return scheme === "Bearer" ? token : null;
 };
-
-export const parseTokenPayload = () => {
-  const token = getToken();
-  if (!token) return null;
-
-  try {
-    const payloadBase64 = token.split(".")[1];
-
-    // base64url 포맷을 base64로 변환
-    const base64 = payloadBase64.replace(/-/g, "+").replace(/_/g, "/");
-    const decodedPayload = decodeURIComponent(
-      atob(base64)
-        .split("")
-        .map(function (c) {
-          return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
-        })
-        .join("")
-    );
-    return JSON.parse(decodedPayload);
-  } catch (error) {
-    console.error("Failed to parse token payload:", error);
-    return null;
-  }
-};
-
-export const getNicknameFromToken = () => {
-  const payload = parseTokenPayload();
-  return payload ? payload.nickname : null;
-};


### PR DESCRIPTION
## 요약
프론트엔드에서 Access/Refresh Token 기반 인증 흐름을 완성하고, 로그아웃 요청 시 백엔드와 연동하여 Redis에서 refresh 토큰을 삭제하도록 개선.

<br><br>

## 작업 내용
- JWT에서 nickname 클레임 제거 → 별도 응답 값으로 분리
- 로그인 성공 시:
  - Access Token 저장 (localStorage)
  - Refresh Token은 쿠키로 자동 저장
  - nickname은 localStorage에 저장
- axios 응답 인터셉터에 Access Token 만료 대응 로직 추가:
  - 401 응답 시 `/auth/reissue` 호출
  - 성공 시 새로운 Access Token 저장 및 원래 요청 재시도
- 로그아웃 버튼 클릭 시:
  - 백엔드에 로그아웃 POST 요청
  - Redis의 refresh 토큰 삭제
  - 쿠키 삭제 및 클라이언트 상태 초기화

<br><br>

## 참고 사항
- refresh 토큰은 클라이언트에서 직접 접근할 수 없으므로 `withCredentials: true` 필수
- 재발급 후 쿠키는 자동으로 브라우저에 반영됨
- 백엔드와의 상태 싱크(토큰 삭제 포함)가 프론트에서 잘 동작함을 확인함
<br><br>

## 관련 이슈

- Close #XXX

<br><br>
