### PR TITLE
feat: OAuth2 소셜 로그인 전체 구현 및 인증 구조 통합

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	// Spring Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	// OAuth2 Login (구글, 네이버 등 소셜 로그인용)
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// Spring Data JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 

--- a/backend/src/main/java/com/swu/auth/dto/GoogleResponse.java
+++ b/backend/src/main/java/com/swu/auth/dto/GoogleResponse.java
@@ -1,0 +1,23 @@
+package com.swu.auth.dto;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response {
+
+    private final Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+
+        this.attribute = attribute;
+    }
+    
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+    
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+}

--- a/backend/src/main/java/com/swu/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/swu/auth/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.swu.auth.dto.request;
+package com.swu.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/swu/auth/dto/NaverResponse.java
+++ b/backend/src/main/java/com/swu/auth/dto/NaverResponse.java
@@ -1,0 +1,22 @@
+package com.swu.auth.dto;
+
+import java.util.Map;
+
+public class NaverResponse implements OAuth2Response {
+   
+    private final Map<String, Object> attribute;
+
+    public NaverResponse(Map<String, Object> attribute) {
+        this.attribute = (Map<String, Object>) attribute.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+    
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+}

--- a/backend/src/main/java/com/swu/auth/dto/OAuth2Response.java
+++ b/backend/src/main/java/com/swu/auth/dto/OAuth2Response.java
@@ -1,0 +1,10 @@
+package com.swu.auth.dto;
+
+public interface OAuth2Response {
+
+    //제공자 (Ex. naver, google, ...)
+    String getProvider();
+    
+    //이메일
+    String getEmail();
+}

--- a/backend/src/main/java/com/swu/auth/entity/PrincipalDetails.java
+++ b/backend/src/main/java/com/swu/auth/entity/PrincipalDetails.java
@@ -2,30 +2,40 @@ package com.swu.auth.entity;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import com.swu.domain.user.entity.User;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-public class CustomUserDetails implements UserDetails {
+@RequiredArgsConstructor
+public class PrincipalDetails implements UserDetails, OAuth2User {
 
     private final User user;
+    private Map<String, Object> attributes;
 
-    public CustomUserDetails(User user) {
-        this.user = user;
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
     }
 
-    // 사용자가 가진 권한 목록 반환
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collection = new ArrayList<>();
 
         collection.add(() -> "ROLE_" + user.getRole());
         return collection;
+    }
+
+    @Override
+    public String getName() {
+        return user.getEmail();
     }
 
     @Override
@@ -57,5 +67,4 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
-
 }

--- a/backend/src/main/java/com/swu/auth/handler/CustomSuccessHandler.java
+++ b/backend/src/main/java/com/swu/auth/handler/CustomSuccessHandler.java
@@ -1,0 +1,63 @@
+package com.swu.auth.handler;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+import com.swu.auth.entity.PrincipalDetails;
+import com.swu.auth.jwt.JWTUtil;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JWTUtil jwtUtil;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        
+        PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
+
+        Long  id = principal.getUser().getId();
+        String nickname = principal.getUser().getNickname();
+        String role = "ROLE_" + principal.getUser().getRole().name();
+
+        
+        // 리프레시 토큰 발급
+        String refresh = jwtUtil.createJwt("refresh", role, id, 86400000L); 
+
+        // Redis에 리프레시 토큰 저장
+        redisTemplate.opsForValue().set("refresh:user:" + id, refresh, 24, TimeUnit.HOURS);
+
+        // 응답 설정
+        response.setStatus(HttpStatus.OK.value());
+        response.addCookie(createCookie("refresh", refresh));
+        response.sendRedirect("http://localhost:3000/");
+
+        log.info("OAuth 로그인 성공: {}, 역할: {}", nickname, role);
+    }
+
+     private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        //cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+    
+}

--- a/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/JWTFilter.java
@@ -3,7 +3,7 @@ package com.swu.auth.jwt;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.user.entity.Role;
 import com.swu.domain.user.entity.User;
 import com.swu.global.response.ApiResponse;
@@ -112,10 +112,10 @@ public class JWTFilter extends OncePerRequestFilter{
                 .build();
 
         // UserDetails에 회원 정보 객체 담기
-        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+        PrincipalDetails principal = new PrincipalDetails(user);
 
         // 스프링 시큐리티 인증 토큰 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        Authentication authToken = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
 
         // 세션에 사용자 등록
         SecurityContextHolder.getContext().setAuthentication(authToken);

--- a/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
@@ -8,7 +8,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import com.swu.auth.dto.request.LoginRequest;
+import com.swu.auth.dto.LoginRequest;
 import com.swu.auth.entity.CustomUserDetails;
 import com.swu.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;

--- a/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
+++ b/backend/src/main/java/com/swu/auth/jwt/LoginFilter.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import com.swu.auth.dto.LoginRequest;
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StreamUtils;
@@ -76,9 +76,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter{
     //로그인 성공시 실행하는 메소드
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
-        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
-        Long  id = customUserDetails.getUser().getId();
-        String nickname = customUserDetails.getUser().getNickname();
+        PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
+        Long  id = principal.getUser().getId();
+        String nickname = principal.getUser().getNickname();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();

--- a/backend/src/main/java/com/swu/auth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/swu/auth/service/CustomOAuth2UserService.java
@@ -39,7 +39,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             
             oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
         } else if (registrationId.equals("google")) {
-            log.info("Kakao user info: {}", oAuth2User.getAttributes());
+            log.info("Google user info: {}", oAuth2User.getAttributes());
 
             oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
         } else {
@@ -58,7 +58,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .loginType(loginType)
                 .role(Role.PREUSER)
                 .build();
-
+            
             userRepository.save(user);
 
             return new PrincipalDetails(user);

--- a/backend/src/main/java/com/swu/auth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/swu/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,69 @@
+package com.swu.auth.service;
+
+import java.util.UUID;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.swu.auth.dto.GoogleResponse;
+import com.swu.auth.dto.NaverResponse;
+import com.swu.auth.dto.OAuth2Response;
+import com.swu.auth.entity.PrincipalDetails;
+import com.swu.domain.user.entity.LoginType;
+import com.swu.domain.user.entity.Role;
+import com.swu.domain.user.entity.User;
+import com.swu.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2Response oAuth2Response = null;
+        if (registrationId.equals("naver")) {
+            log.info("Naver user info: {}", oAuth2User.getAttributes());
+            
+            oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+        } else if (registrationId.equals("google")) {
+            log.info("Kakao user info: {}", oAuth2User.getAttributes());
+
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        } else {
+            return null;
+        }
+
+        String email = oAuth2Response.getEmail();
+        LoginType loginType = LoginType.valueOf(oAuth2Response.getProvider().toUpperCase());
+
+        User existData = userRepository.findByEmail(email).orElse(null);
+
+        if (existData == null) {
+            User user = User.builder()
+                .email(email)
+                .nickname("user_" + UUID.randomUUID().toString().substring(0, 8))
+                .loginType(loginType)
+                .role(Role.PREUSER)
+                .build();
+
+            userRepository.save(user);
+
+            return new PrincipalDetails(user);
+        } else {
+            return new PrincipalDetails(existData); 
+        }
+    }
+}

--- a/backend/src/main/java/com/swu/auth/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/swu/auth/service/CustomUserDetailsService.java
@@ -1,6 +1,6 @@
 package com.swu.auth.service;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.user.entity.User;
 import com.swu.domain.user.repository.UserRepository;
 
@@ -21,6 +21,6 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
-        return new CustomUserDetails(user);
+        return new PrincipalDetails(user);
     }
 }

--- a/backend/src/main/java/com/swu/auth/service/TokenService.java
+++ b/backend/src/main/java/com/swu/auth/service/TokenService.java
@@ -8,6 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.swu.auth.jwt.JWTUtil;
+import com.swu.domain.user.entity.User;
+import com.swu.domain.user.repository.UserRepository;
 import com.swu.global.response.ApiResponse;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -31,6 +33,7 @@ public class TokenService {
 
     private final JWTUtil jwtUtil;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final UserRepository userRepository;
 
     public ResponseEntity<ApiResponse<Void>> reissueToken(HttpServletRequest request, HttpServletResponse response) {
 
@@ -62,7 +65,9 @@ public class TokenService {
 
         // 4. JWT에서 유저 정보 파싱
         Long id = (long) jwtUtil.getId(refresh);
-        String role = jwtUtil.getRole(refresh);
+        User user = userRepository.findById(id)
+            .orElseThrow(() -> new RuntimeException("유저 없음"));
+        String role = "ROLE_" + user.getRole().name();
 
         // 5. Redis에서 저장된 refresh 토큰과 비교
         String redisKey = "refresh:user:" + id;

--- a/backend/src/main/java/com/swu/config/SecurityConfig.java
+++ b/backend/src/main/java/com/swu/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.swu.config;
 
 import com.swu.auth.handler.CustomAuthenticationEntryPoint;
+import com.swu.auth.handler.CustomSuccessHandler;
 import com.swu.auth.jwt.CustomLogoutFilter;
 import com.swu.auth.jwt.JWTFilter;
 import com.swu.auth.jwt.JWTUtil;
@@ -31,38 +32,55 @@ public class SecurityConfig {
     private final RedisTemplate<String, Object> redisTemplate;
     private final CustomOAuth2UserService customOAuth2UserService;
 
+    // 비밀번호 암호화를 위한 Bean 등록
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    // 보안 필터 체인 설정
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
+        // 기본 설정 비활성화: CSRF, FormLogin, HttpBasic
         http
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(httpBasic -> httpBasic.disable());
+        
+        // 경로별 인가 정책
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/ws/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/login/**", "oauth2/**", "/ws/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/users/complete-info").hasRole("PREUSER")
                         .requestMatchers("/api/**").hasRole("USER")
                         .anyRequest().authenticated()
                 );
+        
+        // 인증 예외 처리 핸들러 설정 (401 에러 처리)
         http
                 .exceptionHandling(exception -> exception
                 .authenticationEntryPoint(customAuthenticationEntryPoint) 
-                );       
+                );    
+        
+        // OAuth2 로그인 설정
         http
                 .oauth2Login((oauth2) -> oauth2
+                        .successHandler(new CustomSuccessHandler(jwtUtil, redisTemplate))
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService)));
+        
+        // JWT 로그인 필터 등록 (아이디/비밀번호 기반 로그인)
         http
                 .addFilterAt(new LoginFilter(authenticationConfiguration.getAuthenticationManager(), jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class)
+                // JWT 인증 필터 등록 (모든 요청마다 토큰 검증)
                 .addFilterAfter(new JWTFilter(jwtUtil), LoginFilter.class);
+        
+        // 커스텀 로그아웃 필터 등록 (JWT 기반 로그아웃 처리)
         http
                 .addFilterBefore(new CustomLogoutFilter(jwtUtil, redisTemplate), LogoutFilter.class);
+
+        // 세션 사용 안함
         http
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/backend/src/main/java/com/swu/config/StompJwtInterceptor.java
+++ b/backend/src/main/java/com/swu/config/StompJwtInterceptor.java
@@ -9,7 +9,7 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.auth.jwt.JWTUtil;
 import com.swu.domain.user.entity.User;
 import com.swu.domain.user.repository.UserRepository;
@@ -68,9 +68,9 @@ public class StompJwtInterceptor implements ChannelInterceptor {
                 });
 
             // 4. 인증 정보 등록
-            CustomUserDetails customUserDetails = new CustomUserDetails(user);
+            PrincipalDetails userDetails = new PrincipalDetails(user);
             UsernamePasswordAuthenticationToken authentication = 
-                new UsernamePasswordAuthenticationToken(customUserDetails, token, customUserDetails.getAuthorities());
+                new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
 
             accessor.setUser(authentication);
 

--- a/backend/src/main/java/com/swu/controller/ChatController.java
+++ b/backend/src/main/java/com/swu/controller/ChatController.java
@@ -10,7 +10,7 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Controller;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.room.dto.message.ChatMessage;
 import com.swu.domain.room.service.ChatService;
 import com.swu.domain.room.service.RoomService;
@@ -25,13 +25,14 @@ public class ChatController {
 
     private final ChatService chatService;
     private final RoomService roomService;
+    
     @MessageMapping("/chat/message")
     public void handleChatMessage(@Payload @Valid ChatMessage message, Principal principal) {
         if (!(principal instanceof UsernamePasswordAuthenticationToken authToken)) {
             throw new SecurityException("인증되지 않은 사용자입니다.");
         }
 
-        CustomUserDetails userDetails = (CustomUserDetails) authToken.getPrincipal();
+        PrincipalDetails userDetails = (PrincipalDetails) authToken.getPrincipal();
         User user = userDetails.getUser();
 
         if (!roomService.hasAccessToRoom(message.roomId(), user)) {

--- a/backend/src/main/java/com/swu/controller/DiaryController.java
+++ b/backend/src/main/java/com/swu/controller/DiaryController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.diary.dto.request.DiaryRequest;
 import com.swu.domain.diary.dto.response.DiaryResponse;
 import com.swu.domain.diary.service.DiaryService;
@@ -37,7 +37,7 @@ public class DiaryController {
     @Operation(summary = "일기 생성", description = "일기를 새로 생성합니다.")
     public ResponseEntity<ApiResponse<DiaryResponse>> createDiary(
         @RequestBody @Valid DiaryRequest request,
-        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @AuthenticationPrincipal PrincipalDetails userDetails) {
 
         DiaryResponse response = diaryService.createDiary(userDetails.getUser().getId(), request);
         return ResponseEntity.ok(ApiResponse.success("일기 생성 성공", response));
@@ -47,7 +47,7 @@ public class DiaryController {
     @Operation(summary = "일기 단건 조회", description = "id를 이용해 사용자의 일기를 조회합니다.")
     public ResponseEntity<ApiResponse<DiaryResponse>> getDiary(
         @PathVariable Long id,
-        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @AuthenticationPrincipal PrincipalDetails userDetails) {
 
         DiaryResponse response = diaryService.getDiary(id, userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("일기 조회 성공", response));
@@ -58,7 +58,7 @@ public class DiaryController {
     public ResponseEntity<ApiResponse<List<DiaryResponse>>> getDiaries(
         @RequestParam(required = false)
         @DateTimeFormat(pattern = "yyyy-MM") YearMonth month,
-        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @AuthenticationPrincipal PrincipalDetails userDetails) {
 
         List<DiaryResponse> response = diaryService.getDiaries(userDetails.getUser().getId(), month);
         return ResponseEntity.ok(ApiResponse.success("일기 목록 조회 성공", response));

--- a/backend/src/main/java/com/swu/controller/PlanController.java
+++ b/backend/src/main/java/com/swu/controller/PlanController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.plan.dto.PlanRequest;
 import com.swu.domain.plan.dto.PlanResponse;
 import com.swu.domain.plan.service.PlanService;
@@ -38,7 +38,7 @@ public class PlanController {
     @PostMapping
     public ResponseEntity<ApiResponse<PlanResponse>> createPlan(
             @RequestBody @Valid PlanRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
         PlanResponse response = planService.createPlan(request, userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("플랜 생성 성공", response));
     }
@@ -47,7 +47,7 @@ public class PlanController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<PlanResponse>>> getPlansByDate(
             @RequestParam LocalDate date,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
         List<PlanResponse> responses = planService.getPlansByDate(date, userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("플랜 조회 성공", responses));
     }
@@ -57,7 +57,7 @@ public class PlanController {
     public ResponseEntity<ApiResponse<List<PlanResponse>>> getPlansByMonth(
             @RequestParam int year,
             @RequestParam int month,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
 
         List<PlanResponse> responses = planService.getPlansByMonth(year, month, userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("월별 플랜 조회 성공", responses));
@@ -68,7 +68,7 @@ public class PlanController {
     public ResponseEntity<ApiResponse<PlanResponse>> updatePlan(
             @PathVariable Long planId,
             @RequestBody @Valid PlanRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
 
         PlanResponse response = planService.updatePlan(planId, request, userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("플랜 수정 성공", response));
@@ -78,7 +78,7 @@ public class PlanController {
     @DeleteMapping("/{planId}")
     public ResponseEntity<ApiResponse<Void>> deletePlan(
             @PathVariable Long planId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
         planService.deletePlan(planId, userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("플랜 삭제 성공", null));
     }   

--- a/backend/src/main/java/com/swu/controller/RoomController.java
+++ b/backend/src/main/java/com/swu/controller/RoomController.java
@@ -1,6 +1,6 @@
 package com.swu.controller;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.room.dto.request.RoomRequest;
 import com.swu.domain.room.dto.response.RoomResponse;
 import com.swu.domain.room.service.RoomService;
@@ -27,7 +27,7 @@ public class RoomController {
     @PostMapping
     public ResponseEntity<ApiResponse<RoomResponse>> createRoom(
             @RequestBody RoomRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
         RoomResponse room = roomService.createRoom(request, userDetails.getUser());
         return ResponseEntity.ok(ApiResponse.success("방 생성 성공", room));
     }

--- a/backend/src/main/java/com/swu/controller/RoomMemberController.java
+++ b/backend/src/main/java/com/swu/controller/RoomMemberController.java
@@ -1,7 +1,6 @@
 package com.swu.controller;
 
-
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.room.dto.response.RoomMemberResponse;
 import com.swu.domain.room.service.RoomMemberService;
 import com.swu.global.response.ApiResponse;
@@ -27,7 +26,7 @@ public class RoomMemberController {
     @PostMapping("/{roomId}/join")
     public ResponseEntity<ApiResponse<Void>> joinRoom(
             @PathVariable Long roomId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
 
         roomMemberService.joinRoom(roomId, userDetails.getUser());
         return ResponseEntity.ok(ApiResponse.success("방 참여 성공.", null));
@@ -37,7 +36,7 @@ public class RoomMemberController {
     @PostMapping("/{roomId}/exit")
     public ResponseEntity<ApiResponse<Void>> exitRoom(
             @PathVariable Long roomId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
 
         roomMemberService.exitRoom(roomId, userDetails.getUser());
         return ResponseEntity.ok(ApiResponse.success("방 나가기 성공.", null));

--- a/backend/src/main/java/com/swu/controller/SignalingController.java
+++ b/backend/src/main/java/com/swu/controller/SignalingController.java
@@ -1,6 +1,6 @@
 package com.swu.controller;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.room.dto.message.SignalingMessage;
 import com.swu.domain.room.service.RoomService;
 import com.swu.domain.user.entity.User;
@@ -32,7 +32,7 @@ public class SignalingController {
                 throw new SecurityException("인증되지 않은 사용자입니다.");
             }
     
-            CustomUserDetails userDetails = (CustomUserDetails) authToken.getPrincipal();
+            PrincipalDetails userDetails = (PrincipalDetails) authToken.getPrincipal();
             User user = userDetails.getUser();
     
             if (!roomService.hasAccessToRoom(message.roomId(), user)) {

--- a/backend/src/main/java/com/swu/controller/StudyTimeController.java
+++ b/backend/src/main/java/com/swu/controller/StudyTimeController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.studytime.dto.response.StudyTimeResponse;
 import com.swu.domain.studytime.service.StudyTimeService;
 import com.swu.global.response.ApiResponse;
@@ -32,7 +32,7 @@ public class StudyTimeController {
     @Operation(summary = "스터디 시간 단일 조회", description = "특정 날짜의 스터디 시간을 조회합니다.")
     public ResponseEntity<ApiResponse<StudyTimeResponse>> getStudyTime(
         @RequestParam LocalDate date,
-        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @AuthenticationPrincipal PrincipalDetails userDetails) {
         
         Long userId = userDetails.getUser().getId();
         StudyTimeResponse response = studyTimeService.getStudyTime(userId, date);
@@ -46,7 +46,7 @@ public class StudyTimeController {
     @Operation(summary = "월간 스터디 시간 조회", description = "특정 월의 스터디 시간을 일자별로 조회합니다.")
     public ResponseEntity<ApiResponse<List<StudyTimeResponse>>> getMonthlyStudyTimes(
         @RequestParam YearMonth month,
-        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @AuthenticationPrincipal PrincipalDetails userDetails) {
             
         Long userId = userDetails.getUser().getId();
         List<StudyTimeResponse> response = studyTimeService.getStudyTimes(userId, month);

--- a/backend/src/main/java/com/swu/controller/UserController.java
+++ b/backend/src/main/java/com/swu/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.swu.controller;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.user.dto.request.ExtraInfoRequest;
 import com.swu.domain.user.dto.request.PasswordChangeRequest;
 import com.swu.domain.user.dto.request.SignupRequest;
@@ -54,9 +54,9 @@ public class UserController {
     }
 
     @Operation(summary = "소셜 로그인 유저 추가 정보 입력", description = "닉네임, 프로필 이미지를 입력하여 PREUSER → USER 승격")
-    @PostMapping("/users/complete-info")
+    @PatchMapping("/users/complete-info")
     public ResponseEntity<ApiResponse<Void>> completeInfo(
-        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @AuthenticationPrincipal PrincipalDetails userDetails,
         @RequestPart("info") @Valid ExtraInfoRequest request,
         @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
         String profileUrl = null;
@@ -77,7 +77,7 @@ public class UserController {
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @GetMapping("/users/me")
-    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(@AuthenticationPrincipal PrincipalDetails userDetails) {
         User user = userDetails.getUser();
         UserInfoResponse response = userService.getUserInfo(user.getId());
         return ResponseEntity.ok(ApiResponse.success("내 정보 조회 성공", response));
@@ -86,7 +86,7 @@ public class UserController {
     @Operation(summary = "닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
     @PatchMapping("/users/me/nickname")
     public ResponseEntity<ApiResponse<Void>> updateNickname(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal PrincipalDetails userDetails,
             @RequestBody @Valid UserUpdateRequests.Nickname request) {
         User user = userDetails.getUser();
         userService.updateNickname(user.getId(), request.getNickname());
@@ -96,7 +96,7 @@ public class UserController {
     @Operation(summary = "프로필 이미지 수정", description = "현재 로그인한 사용자의 프로필을 수정합니다.")
     @PatchMapping("/users/me/profileImg")
     public ResponseEntity<ApiResponse<Void>> updateProfileImg(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal PrincipalDetails userDetails,
             @RequestPart(value = "profileImage") MultipartFile profileImage) {
         
         try {
@@ -112,7 +112,7 @@ public class UserController {
     @Operation(summary = "비밀번호 변경", description = "현재 로그인한 사용자의 비밀번호를 변경합니다.")
     @PatchMapping("/users/me/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @AuthenticationPrincipal PrincipalDetails userDetails,
             @RequestBody @Valid PasswordChangeRequest request) {
         User user = userDetails.getUser();
         userService.updatePassword(user.getId(), request.getCurrentPassword(), request.getNewPassword());
@@ -121,7 +121,7 @@ public class UserController {
 
     @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다.")
     @DeleteMapping("/users/me")
-    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal PrincipalDetails userDetails) {
         User user = userDetails.getUser();
         userService.deleteUser(user.getId());
         return ResponseEntity.ok(ApiResponse.success("회원 탈퇴 성공", null));

--- a/backend/src/main/java/com/swu/domain/user/dto/request/ExtraInfoRequest.java
+++ b/backend/src/main/java/com/swu/domain/user/dto/request/ExtraInfoRequest.java
@@ -1,0 +1,10 @@
+package com.swu.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ExtraInfoRequest {
+    @NotBlank
+    private String nickname;
+}

--- a/backend/src/main/java/com/swu/domain/user/entity/Role.java
+++ b/backend/src/main/java/com/swu/domain/user/entity/Role.java
@@ -2,5 +2,6 @@ package com.swu.domain.user.entity;
 
 public enum Role {
     USER,
-    ADMIN
+    ADMIN,
+    PREUSER // 추가 정보 입력 필요
 }

--- a/backend/src/main/java/com/swu/domain/user/entity/User.java
+++ b/backend/src/main/java/com/swu/domain/user/entity/User.java
@@ -71,4 +71,8 @@ public class User {
         this.nickname = "탈퇴한 사용자";
         this.profileImg = null;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/backend/src/main/java/com/swu/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/swu/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.swu.domain.user.dto.request.SignupRequest;
 import com.swu.domain.user.dto.response.UserInfoResponse;
+import com.swu.domain.user.entity.Role;
 import com.swu.domain.user.entity.User;
 import com.swu.domain.user.exception.EmailAlreadyExistsException;
 import com.swu.domain.user.exception.InvalidCurrentPasswordException;
@@ -39,6 +40,22 @@ public class UserService {
         userRepository.save(user);
     }
 
+    @Transactional
+    public void completeExtraInfo(Long userId, String nickname, String profileImg) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저"));
+    
+        user.updateNickname(nickname);
+        if (profileImg != null) {
+            user.updateProfileImg(profileImg);
+        }
+        
+        // 추가정보 입력 후 PREUSER에서 USER로 승격
+        user.updateRole(Role.USER); 
+    
+        userRepository.save(user);
+    }
+    
     @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(Long userId) {
         User user = userRepository.findById(userId)

--- a/backend/src/test/java/com/swu/testconfig/WithMockCustomUserSecurityContextFactory.java
+++ b/backend/src/test/java/com/swu/testconfig/WithMockCustomUserSecurityContextFactory.java
@@ -5,7 +5,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
-import com.swu.auth.entity.CustomUserDetails;
+import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.user.entity.User;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,7 +21,7 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
                 .nickname(annotation.nickname())
                 .build();
 
-        CustomUserDetails userDetails = new CustomUserDetails(user);
+        PrincipalDetails userDetails = new PrincipalDetails(user);
 
         Authentication auth =
                 new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,9 @@
 import "./App.css";
-import React from "react";
-import { Routes, Route, Navigate, Outlet } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { Routes, Route, Navigate, Outlet, useNavigate } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
+import { getAuthHeader, setToken, extractTokenFromHeader } from "./utils/auth";
+import axios from "axios";
 
 import Layout from "./components/Layout";
 import Mypage from "./pages/mypage/Mypage";
@@ -10,14 +12,39 @@ import Planer from "./pages/planer/Planer";
 import StudyRoomList from "./pages/rooms/StudyRoomList";
 import LandingPage from "./pages/landing/LandingPage";
 import StudyRoom from "./pages/rooms/StudyRoom";
+import CompleteInfoPage from "./pages/landing/CompleteInfoPage";
 
 import { isAuthenticated } from "./utils/auth";
 
 // ✅ 인증이 필요한 라우트 래퍼
 const ProtectedRoute = () => {
-  if (!isAuthenticated()) {
-    return <Navigate to="/login" replace />;
-  }
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  useEffect(() => {
+    const checkAuth = async () => {
+      const token = getAuthHeader();
+      if (!token) {
+        try {
+          const res = await axios.post(
+            `${process.env.REACT_APP_API_BASE_URL}/auth/reissue`,
+            {},
+            {
+              withCredentials: true,
+            }
+          );
+          const newToken = extractTokenFromHeader(res);
+          setToken(newToken);
+        } catch (e) {
+          navigate("/", { replace: true });
+        }
+      }
+      setLoading(false);
+    };
+
+    checkAuth();
+  }, [navigate]);
+  if (loading) return <div>로딩 중...</div>;
+
   return (
     <Layout>
       <Outlet />
@@ -40,6 +67,7 @@ function App() {
       <Routes>
         {/* 🔓 인증 없이 접근 가능한 페이지 */}
         <Route path="/" element={<LandingPage />} />
+        <Route path="/complete-info" element={<CompleteInfoPage />} />
 
         {/* 🔐 인증이 필요한 페이지 (공통 레이아웃 포함) */}
         <Route element={<ProtectedRoute />}>

--- a/frontend/src/components/AuthForm.js
+++ b/frontend/src/components/AuthForm.js
@@ -29,7 +29,9 @@ const AuthForm = () => {
   const [showPassword, setShowPassword] = useState(false);
 
   const handleSocialLogin = (platform) => {
-    toast.info(`${platform} 로그인은 준비 중입니다.`);
+    const baseUrl = process.env.REACT_APP_SERVER_ORIGIN;
+
+    window.location.href = `${baseUrl}/oauth2/authorization/${platform.toLowerCase()}`;
   };
 
   const handleProfileImgChange = (e) => {
@@ -63,7 +65,7 @@ const AuthForm = () => {
       const res = await axios.post(
         `${process.env.REACT_APP_API_BASE_URL}/auth/login`,
         { email, password },
-        { headers: { "Content-Type": "application/json" }, withCredentials: true } // refresh token 쿠키 전송
+        { headers: { "Content-Type": "application/json" }, withCredentials: true }
       );
 
       const token = extractTokenFromHeader(res);
@@ -209,11 +211,11 @@ const AuthForm = () => {
 
   const renderSocialLogin = () => (
     <div className={styles.socialLogin}>
-      <div className={styles.socialButton} onClick={() => handleSocialLogin("카카오")}>
+      <div className={styles.socialButton} onClick={() => handleSocialLogin("kakao")}>
         <img src={kakaoLogo} alt="카카오 로그인" className={styles.socialIcon} />
         카카오로 계속하기
       </div>
-      <div className={styles.socialButton} onClick={() => handleSocialLogin("구글")}>
+      <div className={styles.socialButton} onClick={() => handleSocialLogin("google")}>
         <img src={googleLogo} alt="구글 로그인" className={styles.socialIcon} />
         구글로 계속하기
       </div>

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,6 +1,7 @@
 import styles from "./Header.module.css";
 import { useState, useEffect } from "react";
 import { removeToken } from "../utils/auth";
+import { apiGet } from "../utils/api";
 import { FiClock, FiMenu } from "react-icons/fi";
 import MobileSidebar from "./MobileSidebar";
 
@@ -8,7 +9,16 @@ const Header = () => {
   const [studyTime, setStudyTime] = useState("00시간 00분");
   const [currentTime, setCurrentTime] = useState(new Date());
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const nickname = localStorage.getItem("nickname");
+  const [nickname, setNickname] = useState(localStorage.getItem("nickname") || "");
+
+  useEffect(() => {
+    if (!localStorage.getItem("nickname")) {
+      apiGet("/users/me").then((res) => {
+        localStorage.setItem("nickname", res.nickname);
+        setNickname(res.nickname);
+      });
+    }
+  }, []);
 
   const handleLogout = async () => {
     try {

--- a/frontend/src/pages/landing/CompleteInfoPage.js
+++ b/frontend/src/pages/landing/CompleteInfoPage.js
@@ -1,0 +1,113 @@
+// src/pages/CompleteInfoPage.jsx
+import React, { useState, useEffect } from "react";
+import styles from "./CompleteInfoPage.module.css";
+import logoImage from "../../assets/images/StudywithusLogo.png";
+import { toast } from "react-toastify";
+import { setToken, extractTokenFromHeader, getAuthHeader } from "../../utils/auth";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+
+const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB
+
+const CompleteInfoPage = () => {
+  const [nickname, setNickname] = useState("");
+  const [profileImgFile, setProfileImgFile] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchAccessToken = async () => {
+      try {
+        const res = await axios.post(
+          `${process.env.REACT_APP_API_BASE_URL}/auth/reissue`,
+          {},
+          { withCredentials: true }
+        );
+        const token = extractTokenFromHeader(res);
+        console.log("Access Token:", token);
+        setToken(token);
+      } catch (e) {
+        toast.error("로그인 세션이 만료되었습니다.");
+        navigate("/");
+      }
+    };
+
+    fetchAccessToken();
+  }, []);
+
+  const handleProfileImgChange = (e) => {
+    const file = e.target.files[0];
+    if (file && file.size > MAX_FILE_SIZE) {
+      toast.error("이미지 크기는 1MB를 넘을 수 없습니다.");
+      return;
+    }
+    setProfileImgFile(file);
+  };
+
+  const handleSubmit = async () => {
+    if (!nickname.trim()) {
+      toast.error("닉네임을 입력해주세요.");
+      return;
+    }
+
+    try {
+      const formData = new FormData();
+      const json = JSON.stringify({ nickname });
+      const blob = new Blob([json], { type: "application/json" });
+
+      formData.append("info", blob);
+
+      if (profileImgFile) {
+        formData.append("profileImage", profileImgFile);
+      }
+
+      await axios.patch(`${process.env.REACT_APP_API_BASE_URL}/users/complete-info`, formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+          Authorization: getAuthHeader(),
+        },
+        withCredentials: true,
+      });
+
+      toast.success("정보가 성공적으로 저장되었습니다!");
+
+      navigate("/rooms");
+    } catch (err) {
+      toast.error("정보 저장에 실패했습니다.");
+    }
+  };
+
+  return (
+    <div className={styles.pageWrapper}>
+      <div className={styles.container}>
+        <img src={logoImage} alt="StudyWithUs 로고" className={styles.logo} />
+        <h2 className={styles.title}>추가 정보 입력</h2>
+        <p className={styles.subtitle}>서비스를 사용하기 위한 정보를 완성해주세요</p>
+
+        <input
+          type="text"
+          placeholder="닉네임을 입력하세요"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          className={styles.input}
+        />
+
+        <label htmlFor="profileImg" className={styles.fileLabel}>
+          {profileImgFile ? profileImgFile.name : "프로필 이미지 선택"}
+        </label>
+        <input
+          id="profileImg"
+          type="file"
+          accept="image/*"
+          onChange={handleProfileImgChange}
+          className={styles.fileInput}
+        />
+
+        <button onClick={handleSubmit} className={styles.button}>
+          완료하고 입장하기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CompleteInfoPage;

--- a/frontend/src/pages/landing/CompleteInfoPage.module.css
+++ b/frontend/src/pages/landing/CompleteInfoPage.module.css
@@ -1,0 +1,90 @@
+.pageWrapper {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(to left, #f0f4f8, #e2d1c3);
+}
+
+.container {
+  width: 100%;
+  max-width: 420px;
+  padding: 2rem;
+  border-radius: 12px;
+  background-color: #fffaf4;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  text-align: center;
+}
+
+.logo {
+  width: 110px;
+  margin-bottom: 1.2rem;
+}
+
+.title {
+  font-size: 1.4rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: #4b3621;
+}
+
+.subtitle {
+  font-size: 0.95rem;
+  color: #777;
+  margin-bottom: 1.5rem;
+}
+
+.input {
+  width: 100%;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  font-size: 1rem;
+  background-color: #fffdf8;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.03);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus {
+  border-color: #a15b3d;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(161, 91, 61, 0.2);
+}
+
+.fileLabel {
+  display: block;
+  background-color: #f0e8e2;
+  color: #4b3621;
+  font-size: 0.95rem;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  margin-bottom: 1rem;
+  transition: background-color 0.2s ease;
+}
+
+.fileLabel:hover {
+  background-color: #e2d5c8;
+}
+
+.fileInput {
+  display: none;
+}
+
+.button {
+  width: 100%;
+  background-color: #a15b3d;
+  color: white;
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.button:hover {
+  background-color: #8a462e;
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -50,11 +50,7 @@ apiClient.interceptors.response.use(
       }
     }
 
-    if (status === 401) {
-      alert("로그인이 필요합니다. 다시 로그인 해주세요.");
-      removeToken();
-      window.location.href = "/";
-    } else if (status >= 500) {
+    if (status >= 500) {
       alert("서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.");
     }
 


### PR DESCRIPTION
## 요약
OAuth2 기반 소셜 로그인 기능을 전반적으로 구현하고, 인증 주체를 PrincipalDetails로 통합함.

<br><br>

## 작업 내용
###  백엔드
인증 구조 리팩터링 및 통합
- 기존 CustomUserDetails 제거
- PrincipalDetails를 UserDetails와 OAuth2User의 구현체로 통합
- 일반 로그인과 소셜 로그인 유저 모두 PrincipalDetails 기반으로 인증 처리 가능하도록 재구성

소셜 로그인 플로우 구축
- OAuth2 성공 시 PREUSER 권한 부여
- 추가 정보 입력 완료 시 USER 권한으로 승격 처리
- ROLE 기반으로 로그인 성공 후 리다이렉트 분기 처리
- SecurityConfig에 소셜 로그인 관련 경로 허용

핵심 OAuth2 컴포넌트 구현
- Google/Naver 응답 DTO 및 공통 인터페이스 구현
- `CustomOAuth2UserService`: Google/Naver 사용자 정보 처리 및 유저 식별
- `CustomSuccessHandler`: 로그인 성공 시 토큰 발급, Redis 저장, 리다이렉트 처리

토큰 처리 개선
- 리프레시 토큰을 통한 Access Token 재발급 시 최신 권한(Role) 반영

기타 정리
- 불필요한 api.js 레거시 코드 제거

###  프론트엔드
최초 소셜 로그인 이후 처리 로직
- `/complete-info` 페이지에서 Access Token 재발급 후 저장
- 추가 정보 입력(PATCH `/users/complete-info`) 완료 후 `/rooms`로 이동

추가 정보 입력 폼 UI 구현
- 닉네임 + 프로필 이미지 업로드 가능
- 유효성 검사 및 1MB 초과 이미지 제한

공통 인증 처리 
- App.js에 토큰 없을 경우 reissue 요청 로직 추가
- 로그인 이후 페이지 접근 시 자동으로 Access Token 발급 받도록 구성
<br><br>

## 참고 사항
<br><br>

## 관련 이슈

- Close #XXX

<br><br>
