### PR TITLE
feat: OAuth2 Kakao 로그인 추가

### DIFF
--- a/backend/src/main/java/com/swu/auth/dto/KakaoResponse.java
+++ b/backend/src/main/java/com/swu/auth/dto/KakaoResponse.java
@@ -2,17 +2,17 @@ package com.swu.auth.dto;
 
 import java.util.Map;
 
-public class NaverResponse implements OAuth2Response {
-   
+public class KakaoResponse implements OAuth2Response {
+
     private final Map<String, Object> attribute;
 
-    public NaverResponse(Map<String, Object> attribute) {
-        this.attribute = (Map<String, Object>) attribute.get("response");
+    public KakaoResponse(Map<String, Object> attribute) {
+        this.attribute = (Map<String, Object>) attribute.get("kakao_account");
     }
-
+    
     @Override
     public String getProvider() {
-        return "naver";
+        return "kakao";
     }
     
     @Override

--- a/backend/src/main/java/com/swu/auth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/swu/auth/service/CustomOAuth2UserService.java
@@ -9,7 +9,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import com.swu.auth.dto.GoogleResponse;
-import com.swu.auth.dto.NaverResponse;
+import com.swu.auth.dto.KakaoResponse;
 import com.swu.auth.dto.OAuth2Response;
 import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.user.entity.LoginType;
@@ -34,10 +34,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
 
         OAuth2Response oAuth2Response = null;
-        if (registrationId.equals("naver")) {
-            log.info("Naver user info: {}", oAuth2User.getAttributes());
+        if (registrationId.equals("kakao")) {
+            log.info("Kakao user info: {}", oAuth2User.getAttributes());
             
-            oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+            oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
         } else if (registrationId.equals("google")) {
             log.info("Google user info: {}", oAuth2User.getAttributes());
 
@@ -48,7 +48,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String email = oAuth2Response.getEmail();
         LoginType loginType = LoginType.valueOf(oAuth2Response.getProvider().toUpperCase());
-
+      
         User existData = userRepository.findByEmail(email).orElse(null);
 
         if (existData == null) {

--- a/frontend/src/pages/landing/CompleteInfoPage.js
+++ b/frontend/src/pages/landing/CompleteInfoPage.js
@@ -68,8 +68,15 @@ const CompleteInfoPage = () => {
         withCredentials: true,
       });
 
-      toast.success("정보가 성공적으로 저장되었습니다!");
+      const res = await axios.post(
+        `${process.env.REACT_APP_API_BASE_URL}/auth/reissue`,
+        {},
+        { withCredentials: true }
+      );
+      const newToken = extractTokenFromHeader(res);
+      setToken(newToken);
 
+      toast.success("정보가 성공적으로 저장되었습니다!");
       navigate("/rooms");
     } catch (err) {
       toast.error("정보 저장에 실패했습니다.");


### PR DESCRIPTION
## 요약
카카오 로그인 추가완료
<br><br>

## 작업 내용
- KakaoResponse 추가 (email만 받음)
- NaverResponse 삭제
- 최초 소셜로그인 시 추가정보 제출 후 reissue 요청해서 역할 최신화
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #XXX

<br><br>
