### PR TITLE
feat: 마이페이지 통계 시각화 및 API 연결

### DIFF
--- a/backend/src/main/java/com/swu/controller/PlanController.java
+++ b/backend/src/main/java/com/swu/controller/PlanController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.plan.dto.PlanRequest;
 import com.swu.domain.plan.dto.PlanResponse;
+import com.swu.domain.plan.dto.PlanStatsResponse;
 import com.swu.domain.plan.service.PlanService;
 import com.swu.global.response.ApiResponse;
 
@@ -61,6 +62,14 @@ public class PlanController {
 
         List<PlanResponse> responses = planService.getPlansByMonth(year, month, userDetails.getUser().getId());
         return ResponseEntity.ok(ApiResponse.success("월별 플랜 조회 성공", responses));
+    }
+
+    @Operation(summary = "전체 플랜 통계 조회", description = "사용자의 전체 플랜 수와 그중 완료된 플랜 수를 반환합니다.")
+    @GetMapping("/stats")
+    public ResponseEntity<ApiResponse<PlanStatsResponse>> getPlanStats(
+            @AuthenticationPrincipal PrincipalDetails userDetails) {
+        PlanStatsResponse response = planService.getPlanStats(userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("전체 플랜 통계 조회 성공", response));
     }
 
     @Operation(summary = "특정 플랜 수정", description = "특정 플랜을 수정합니다.")

--- a/backend/src/main/java/com/swu/controller/StudyTimeController.java
+++ b/backend/src/main/java/com/swu/controller/StudyTimeController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.swu.auth.entity.PrincipalDetails;
 import com.swu.domain.studytime.dto.response.StudyTimeResponse;
+import com.swu.domain.studytime.dto.response.StudyTimeTotalResponse;
 import com.swu.domain.studytime.service.StudyTimeService;
 import com.swu.global.response.ApiResponse;
 
@@ -52,5 +53,17 @@ public class StudyTimeController {
         List<StudyTimeResponse> response = studyTimeService.getStudyTimes(userId, month);
 
         return ResponseEntity.ok(ApiResponse.success("월간 스터디 시간 목록 조회 성공", response));
+    }
+
+    @GetMapping("/total")
+    @Operation(summary = "누적 공부 시간 조회", description = "사용자의 전체 공부 시간을 분 단위로 반환합니다.")
+    public ResponseEntity<ApiResponse<StudyTimeTotalResponse>> getTotalStudyTime(
+        @AuthenticationPrincipal PrincipalDetails userDetails) {
+
+        Long userId = userDetails.getUser().getId();
+        int totalMinutes = studyTimeService.getTotalStudyMinutes(userId);
+
+        StudyTimeTotalResponse response = new StudyTimeTotalResponse(totalMinutes);
+        return ResponseEntity.ok(ApiResponse.success("누적 공부 시간 조회 성공", response));
     }
 }

--- a/backend/src/main/java/com/swu/domain/plan/dto/PlanStatsResponse.java
+++ b/backend/src/main/java/com/swu/domain/plan/dto/PlanStatsResponse.java
@@ -1,0 +1,12 @@
+package com.swu.domain.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PlanStatsResponse {
+    private int totalPlans;
+    private int completedPlans;
+}
+

--- a/backend/src/main/java/com/swu/domain/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/swu/domain/plan/repository/PlanRepository.java
@@ -21,4 +21,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     // 필요 시: 전체 Plan 날짜별 정렬 (사용자 전용)
     List<Plan> findByUserIdOrderByPlanDateDesc(Long userId);
+
+    // 특정 사용자 소유의 전체 Plan 목록
+    List<Plan> findByUserId(Long userId);
 }

--- a/backend/src/main/java/com/swu/domain/plan/service/PlanService.java
+++ b/backend/src/main/java/com/swu/domain/plan/service/PlanService.java
@@ -2,6 +2,7 @@ package com.swu.domain.plan.service;
 
 import com.swu.domain.plan.dto.PlanRequest;
 import com.swu.domain.plan.dto.PlanResponse;
+import com.swu.domain.plan.dto.PlanStatsResponse;
 import com.swu.domain.plan.entity.Plan;
 import com.swu.domain.plan.repository.PlanRepository;
 import com.swu.domain.plan.exception.PlanNotFoundException;
@@ -64,6 +65,16 @@ public class PlanService {
                 .map(PlanResponse::from)
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public PlanStatsResponse getPlanStats(Long userId) {
+        log.debug("유저 ID 플랜Stats 조회", userId);
+        List<Plan> plans = planRepository.findByUserId(userId);
+        int total = plans.size();
+        int completed = (int) plans.stream().filter(Plan::isCompleted).count();
+        return new PlanStatsResponse(total, completed);
+    }
+    
 
     @Transactional
     public PlanResponse updatePlan(Long planId, PlanRequest request, Long userId) {

--- a/backend/src/main/java/com/swu/domain/studytime/dto/response/StudyTimeTotalResponse.java
+++ b/backend/src/main/java/com/swu/domain/studytime/dto/response/StudyTimeTotalResponse.java
@@ -1,0 +1,3 @@
+package com.swu.domain.studytime.dto.response;
+
+public record StudyTimeTotalResponse(int totalMinutes) {}

--- a/backend/src/main/java/com/swu/domain/studytime/repository/StudyTimeRepository.java
+++ b/backend/src/main/java/com/swu/domain/studytime/repository/StudyTimeRepository.java
@@ -5,10 +5,16 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.swu.domain.studytime.entity.StudyTime;
+
+import io.lettuce.core.dynamic.annotation.Param;
 
 public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
     Optional<StudyTime> findByUserIdAndRecordDate(Long userId, LocalDate date);
     List<StudyTime> findByUserIdAndRecordDateBetween(Long userId, LocalDate start, LocalDate end);
+    
+    @Query("SELECT COALESCE(SUM(s.totalMinutes), 0) FROM StudyTime s WHERE s.user.id = :userId")
+    int getTotalMinutesByUserId(@Param("userId") Long userId);
 }   

--- a/backend/src/main/java/com/swu/domain/studytime/service/StudyTimeService.java
+++ b/backend/src/main/java/com/swu/domain/studytime/service/StudyTimeService.java
@@ -58,4 +58,9 @@ public class StudyTimeService {
         studyTime.addMinutes(minutes); // 누적
         studyTimeRepository.save(studyTime);
     }
+
+    @Transactional(readOnly = true)
+    public int getTotalStudyMinutes(Long userId) {
+        return studyTimeRepository.getTotalMinutesByUserId(userId);
+    }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.9.0",
         "canvas-confetti": "^1.9.3",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
         "react-quill": "^2.0.0",
@@ -2965,6 +2966,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -5624,6 +5632,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-types": {
@@ -14209,6 +14230,16 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dev-utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "axios": "^1.9.0",
     "canvas-confetti": "^1.9.3",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
     "react-quill": "^2.0.0",

--- a/frontend/src/components/Modal.module.css
+++ b/frontend/src/components/Modal.module.css
@@ -53,6 +53,7 @@
   border-radius: 10px;
   font-size: 1rem;
   cursor: pointer;
+  margin-top: 1rem;
 }
 
 .modalClose:hover {

--- a/frontend/src/components/Mypage/Modal.module.css
+++ b/frontend/src/components/Mypage/Modal.module.css
@@ -1,0 +1,71 @@
+.input {
+  width: 100%;
+  padding: 8px;
+  margin-top: 1rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+.input:focus {
+  border-color: #8b4513;
+  outline: none;
+}
+
+.errorText {
+  color: red;
+  font-size: 13px;
+  margin-top: 0.5rem;
+}
+
+/* 프로필 변경 모달 */
+.fileLabel {
+  width: 100%;
+  height: 45px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f9f9f9;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #555;
+  transition: background-color 0.3s;
+}
+
+.fileLabel:hover {
+  background-color: #f0f0f0;
+}
+
+.fileInput {
+  display: none;
+}
+
+/* 회원 탈퇴 */
+.withdrawContent {
+  padding: 1rem 0;
+  text-align: center;
+  line-height: 1.6;
+}
+
+.warningText {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #212529;
+  margin-bottom: 0.5rem;
+}
+
+.detailText {
+  font-size: 0.9rem;
+  color: #495057;
+}
+
+.highlight {
+  color: #c92a2a;
+  font-weight: 700;
+}
+
+.emphasis {
+  color: #e03131;
+  font-weight: 500;
+}

--- a/frontend/src/components/Mypage/NicknameModal.js
+++ b/frontend/src/components/Mypage/NicknameModal.js
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import Modal from "../Modal";
+import styles from "./Modal.module.css";
+import { apiPatch } from "../../utils/api";
+import { toast } from "react-toastify";
+
+const NicknameModal = ({ isOpen, onClose, onUpdate }) => {
+  const [nickname, setNickname] = useState("");
+
+  const handleConfirm = async () => {
+    try {
+      await apiPatch("/users/me/nickname", { nickname });
+      toast.success("닉네임이 변경되었습니다.");
+      onClose();
+      onUpdate();
+    } catch (err) {
+      console.error("닉네임 변경 실패", err);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="닉네임 수정"
+      confirmText="저장"
+      onConfirm={handleConfirm}
+    >
+      <input
+        type="text"
+        placeholder="새 닉네임 입력"
+        value={nickname}
+        onChange={(e) => setNickname(e.target.value)}
+        className={styles.input}
+      />
+    </Modal>
+  );
+};
+
+export default NicknameModal;

--- a/frontend/src/components/Mypage/PasswordModal.js
+++ b/frontend/src/components/Mypage/PasswordModal.js
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import Modal from "../Modal";
+import styles from "./Modal.module.css";
+import { apiPatch, extractErrorInfo } from "../../utils/api";
+import { toast } from "react-toastify";
+import { validatePassword } from "../../utils/validation";
+
+const PasswordModal = ({ isOpen, onClose }) => {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleConfirm = async () => {
+    setError("");
+
+    if (!validatePassword(newPassword)) {
+      setError("비밀번호는 최소 4자 이상이어야 합니다.");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError("새 비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    try {
+      await apiPatch("/users/me/password", {
+        currentPassword,
+        newPassword,
+      });
+      toast.success("비밀번호가 변경되었습니다.");
+      onClose();
+    } catch (err) {
+      console.error("비밀번호 변경 실패", err);
+      const { status } = extractErrorInfo(err);
+      if (status === 409) {
+        setError("현재 비밀번호가 올바르지 않습니다.");
+      }
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="비밀번호 변경"
+      confirmText="변경"
+      onConfirm={handleConfirm}
+    >
+      <input
+        type="password"
+        placeholder="현재 비밀번호"
+        value={currentPassword}
+        onChange={(e) => setCurrentPassword(e.target.value)}
+        className={styles.input}
+      />
+      <input
+        type="password"
+        placeholder="새 비밀번호"
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+        className={styles.input}
+      />
+      <input
+        type="password"
+        placeholder="새 비밀번호 확인"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+        className={styles.input}
+      />
+      {error && <p className={styles.errorText}>{error}</p>}
+    </Modal>
+  );
+};
+
+export default PasswordModal;

--- a/frontend/src/components/Mypage/ProfileImgModal.js
+++ b/frontend/src/components/Mypage/ProfileImgModal.js
@@ -1,0 +1,67 @@
+import { useState, useEffect } from "react";
+import styles from "./Modal.module.css";
+import Modal from "../Modal";
+import axios from "axios";
+import { getAuthHeader } from "../../utils/auth";
+import { toast } from "react-toastify";
+import { extractErrorInfo } from "../../utils/api";
+
+const ProfileImgModal = ({ isOpen, onClose, onUpdate }) => {
+  const [file, setFile] = useState(null);
+
+  const handleConfirm = async () => {
+    if (!file) {
+      alert("이미지를 선택해주세요.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("profileImage", file);
+
+    try {
+      await axios.patch(`${process.env.REACT_APP_API_BASE_URL}/users/me/profileImg`, formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+          Authorization: getAuthHeader(),
+        },
+      });
+      toast.success("프로필 이미지가 변경되었습니다.");
+      onClose();
+      onUpdate();
+      setFile(null);
+    } catch (err) {
+      const { status } = extractErrorInfo(err);
+      console.error("이미지 업로드 실패", err);
+      if (status === 500) {
+        toast.error("1MB 이하의 이미지로 업로드 해주세요.");
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (!isOpen) setFile(null);
+  }, [isOpen]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="프로필 이미지 변경"
+      confirmText="저장"
+      onConfirm={handleConfirm}
+    >
+      <label htmlFor="profileImg" className={styles.fileLabel}>
+        {file ? file.name : "프로필 이미지 선택"}
+      </label>
+      <input
+        id="profileImg"
+        type="file"
+        accept="image/*"
+        onChange={(e) => setFile(e.target.files[0])}
+        className={styles.fileInput}
+      />
+    </Modal>
+  );
+};
+
+export default ProfileImgModal;

--- a/frontend/src/components/Mypage/WithdrawModal.js
+++ b/frontend/src/components/Mypage/WithdrawModal.js
@@ -1,0 +1,50 @@
+import Modal from "../Modal";
+import styles from "./Modal.module.css";
+import { apiDelete } from "../../utils/api";
+import { removeToken } from "../../utils/auth";
+
+const WithdrawModal = ({ isOpen, onClose }) => {
+  const handleWithdraw = async () => {
+    try {
+      // 1. 유저 탈퇴 요청
+      await apiDelete("/users/me");
+
+      // 2. 서버 refreshToken 삭제 요청
+      await fetch(`${process.env.REACT_APP_API_BASE_URL}/auth/logout`, {
+        method: "POST",
+        credentials: "include", // refresh token 쿠키 전송
+      });
+
+      // 3. 클라이언트 정리
+      removeToken();
+      localStorage.removeItem("nickname");
+
+      alert("회원 탈퇴가 완료되었습니다.");
+      window.location.href = "/";
+    } catch (err) {
+      console.error("탈퇴 실패", err);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="회원 탈퇴"
+      confirmText="탈퇴하기"
+      onConfirm={handleWithdraw}
+    >
+      <p className={styles.warningText}>
+        정말 <span className={styles.highlight}>회원 탈퇴</span>를 진행하시겠어요?
+      </p>
+      <p className={styles.detailText}>
+        탈퇴 시 <b>계정 정보</b>와 <b>공부 기록</b>이 모두{" "}
+        <span className={styles.emphasis}>영구 삭제</span>되며,
+        <br />
+        <span className={styles.emphasis}>되돌릴 수 없습니다.</span>
+      </p>
+    </Modal>
+  );
+};
+
+export default WithdrawModal;

--- a/frontend/src/components/common/Button.js
+++ b/frontend/src/components/common/Button.js
@@ -1,0 +1,15 @@
+import styles from "./Button.module.css";
+import clsx from "clsx";
+
+const Button = ({ children, type = "default", fullWidth = true, onClick }) => {
+  return (
+    <button
+      className={clsx(styles.btn, styles[type], fullWidth && styles.fullWidth)}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/frontend/src/components/common/Button.module.css
+++ b/frontend/src/components/common/Button.module.css
@@ -1,0 +1,39 @@
+.btn {
+  padding: 0.6rem 1.2rem;
+  font-weight: 500;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.default {
+  background-color: #495057;
+  color: white;
+}
+
+.default:hover {
+  background-color: #343a40;
+}
+
+.primary {
+  background-color: #a15b3d;
+  color: white;
+}
+
+.primary:hover {
+  background-color: #87432f;
+}
+
+.danger {
+  background-color: #bb4848;
+  color: white;
+}
+
+.danger:hover {
+  background-color: #a83232;
+}

--- a/frontend/src/hooks/useCurrentUser.js
+++ b/frontend/src/hooks/useCurrentUser.js
@@ -1,23 +1,23 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { apiGet } from "../utils/api";
 
 const useCurrentUser = () => {
   const [user, setUser] = useState(null);
 
-  useEffect(() => {
-    const fetchUser = async () => {
-      try {
-        const data = await apiGet("/users/me");
-        setUser(data);
-      } catch (err) {
-        console.error("유저 정보 불러오기 실패", err);
-      }
-    };
-
-    fetchUser();
+  const fetchUser = useCallback(async () => {
+    try {
+      const data = await apiGet("/users/me");
+      setUser(data);
+    } catch (err) {
+      console.error("유저 정보 불러오기 실패", err);
+    }
   }, []);
 
-  return user;
+  useEffect(() => {
+    fetchUser();
+  }, [fetchUser]);
+
+  return { user, refreshUser: fetchUser };
 };
 
 export default useCurrentUser;

--- a/frontend/src/pages/mypage/Mypage.module.css
+++ b/frontend/src/pages/mypage/Mypage.module.css
@@ -1,251 +1,262 @@
-.wrapper {
-  padding: 20px;
+.loadingContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 80vh;
+  font-size: 1rem;
+  color: #495057;
+}
+
+.container {
   width: 100%;
   height: 100%;
-  display: grid;
-  grid-template-columns: 1fr 2fr 1fr;
-  gap: 20px;
+  font-family: "Pretendard", sans-serif;
 }
 
-.title {
-  font-size: 28px;
-  font-weight: bold;
-  margin-bottom: 30px;
-  color: #333;
-  grid-column: 1 / -1;
-}
-
-.section {
-  background-color: #fff;
-  padding: 30px;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  margin-bottom: 20px;
-}
-
-.chartContainer {
+.mainLayout {
   width: 100%;
-  height: 300px;
-  margin-top: 20px;
+  height: 100%;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+/* 왼쪽 프로필 + 계정 영역 */
+.leftSection {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: #fffdf8;
+  border-radius: 1rem;
+  border: 1px solid #e9ecef;
+  padding: 2rem 1.5rem;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.03);
+  height: 100%;
 }
 
 .profileSection {
   display: flex;
   flex-direction: column;
   align-items: center;
-  text-align: center;
-  padding: 20px;
 }
 
-.profileImage {
-  width: 100px;
-  height: 100px;
+.profileImageWrapper {
+  width: 120px;
+  height: 120px;
+  margin-bottom: 1rem;
+}
+
+.profileImg {
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   object-fit: cover;
-  border: 2px solid #ccc;
-  margin-bottom: 10px;
+  background-color: #dee2e6;
 }
 
 .profileInfo {
-  margin-bottom: 20px;
+  width: 100%;
 }
 
-.profileInfo h3 {
+.profileInfo dl {
   margin: 0;
-  font-size: 20px;
-  color: #333;
+  padding: 0;
 }
 
-.profileInfo p {
-  margin: 5px 0;
-  color: #666;
-}
-
-.editButton {
-  background-color: #8884d8;
-  color: #fff;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: background-color 0.3s;
-  width: 100%;
-}
-
-.editButton:hover {
-  background-color: #6a6dd1;
-}
-
-.friendSection {
-  background-color: #fff;
-  padding: 20px;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  height: 100%;
-}
-
-.friendSection h4 {
-  margin-bottom: 10px;
+.profileInfo dt {
   font-weight: bold;
-  color: #333;
+  margin-top: 0.8rem;
+  font-size: 0.95rem;
+  color: #212529;
 }
 
-.friendList {
-  height: 220px;
-  border-radius: 8px;
-  margin-top: 10px;
-  padding: 10px;
-  overflow-y: auto;
+.profileInfo dd {
+  margin: 0.2rem 0 1rem 0;
+  font-size: 0.95rem;
+  color: #343a40;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: white;
+  background-color: #b08d57;
+  border-radius: 1rem;
+}
+
+.loginTypeBadge {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: 9999px;
+  color: white;
+  text-align: center;
+}
+
+.login-local {
+  background-color: #6c757d;
+}
+
+.login-kakao {
+  background-color: #f7e600;
+  color: #3c1e1e;
+}
+
+.login-google {
+  background-color: #4285f4;
+}
+
+.btnWrapper {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  margin-top: 1.5rem;
+  gap: 1rem;
 }
 
-.friendItem {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background-color: #f4f4f4;
-  padding: 10px;
-  border-radius: 8px;
+.accountSection {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #dee2e6;
 }
 
-.friendAvatar {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  object-fit: cover;
+.accountSection h3 {
+  font-size: 1.1rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
 }
 
-.friendInfo {
+.notice {
+  font-size: 0.8rem;
+  color: #868e96;
+  margin-top: 1rem;
+  text-align: left;
+}
+
+/* 오른쪽 통계 영역 */
+.rightSection {
+  flex: 8;
   display: flex;
   flex-direction: column;
-  font-size: 14px;
-  color: #444;
-}
-
-.inputField {
-  width: 100%;
-  height: 30px;
-  margin-bottom: 10px;
-  padding: 0 10px;
-  border-radius: 6px;
-  border: 1px solid #ccc;
-}
-
-.subGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-  margin-top: 20px;
-  grid-column: 1 / -1;
-}
-
-.subSection {
-  background-color: #fff;
-  padding: 20px;
+  background-color: #fffdf8;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  padding: 1.5rem;
+  height: 100%;
+  overflow: hidden;
 }
 
-.modalOverlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(0, 0, 0, 0.4);
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.summaryCard {
+  background-color: #ffffff;
+  border: 1px solid #dee2e6;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  text-align: center;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.03);
+}
+
+.summaryCard:hover {
+  transform: translateY(-2px);
+}
+
+.summaryLabel {
+  font-size: 0.9rem;
+  color: #868e96;
+  margin-bottom: 0.5rem;
+}
+
+.summaryValue {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #1c1f22;
+}
+
+.statsCard {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border: 1px solid #e9ecef;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.03);
+}
+
+.monthHeader {
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 999;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
 }
 
-.modal {
-  background-color: #fff;
-  padding: 30px;
-  border-radius: 12px;
-  width: 300px;
+.monthHeader button {
+  background: none;
+  border: none;
+  color: #495057;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.monthHeader button:hover {
+  color: #339af0;
+}
+
+.monthHeader span {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #212529;
+}
+
+.statsGraphSection {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 2rem;
 }
 
-.modalButtons {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-}
-
-.submitBtn,
-.cancelBtn {
+.graphBlock {
   flex: 1;
-  padding: 8px;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-weight: bold;
+  background: white;
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid #e9ecef;
 }
 
-.submitBtn {
-  background-color: #8884d8;
-  color: white;
-}
-
-.cancelBtn {
-  background-color: #ccc;
-  color: #333;
-}
-
-.rankButtons {
+.emptyMessage {
+  height: 100%;
   display: flex;
-  gap: 10px;
-  margin-bottom: 10px;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: #868e96;
+  background-color: #f8f9fa;
+  border-radius: 0.5rem;
+  border: 1px dashed #ced4da;
 }
 
-.rankButtons button {
-  padding: 6px 14px;
-  font-size: 13px;
-  border: 1px solid #ccc;
-  background-color: #f4f4f4;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-}
-
-.rankButtons button:hover {
-  background-color: #e0e0e0;
-}
-
-.activeBtn {
-  background-color: #555ac0;
-  color: #332ba1;
-  font-weight: bold;
-  border-color: #555ac0;
-}
-
-.rankItem {
-  display: flex;
-  justify-content: space-between;
-  padding: 8px 12px;
-  margin: 5px 0;
-  border-radius: 6px;
-  background-color: #f7f7f7;
-  font-size: 14px;
-  color: #444;
-}
-
-.rankNum {
-  width: 40px;
-  font-weight: bold;
-  color: #555ac0;
-}
-
-.rankName {
+.extraStatsSection {
   flex: 1;
+  display: flex;
+  gap: 2rem;
+  margin-top: 2rem;
 }
 
-.rankHours {
-  font-size: 13px;
-  color: #666;
+.chartBox {
+  flex: 1;
+  background: white;
+  border: 1px solid #e9ecef;
+  padding: 1rem;
+  border-radius: 1rem;
 }


### PR DESCRIPTION
## 요약
사용자 마이페이지를 전반적으로 구현하고, 시각화 통계를 통해 사용자의 학습 데이터를 한눈에 볼 수 있도록 개선함.
회원 정보 수정, 그래프, 요약 카드 등 사용자 경험을 향상시키는 주요 기능들을 추가.
<br><br>

## 작업 내용
**마이페이지 전반 기능 구현**
  - 오늘 공부 시간 / 누적 공부 시간 / 전체 일기 작성 개수 / 플랜 달성 개수 표시
  - 가입일을 한국어 날짜+요일 형식으로 포맷하여 표시
  - 로그인 방식(Local/Kakao/Google)에 따른 뱃지 색상 스타일 적용
  - 닉네임, 프로필 이미지, 비밀번호 변경(LOCAL만 가능), 회원 탈퇴 기능 모달 분리 및 적용
  - 회원탈퇴시 로컬스토리지 제거 및 API 요청으로 Redis Refresh까지 제거 요청

**그래프 구현**
  - `react-chartjs-2` + `chart.js` 기반 막대그래프 도입
  - 월별 공부 시간 그래프
  - 월별 완료된 플랜 수 그래프
  - X축을 월의 일 수(1일 ~ 말일)로 고정하여 공백 포함 시각화

**공통 컴포넌트**
  - Button 컴포넌트 생성 (primary / default / danger 타입)

**백엔드 API 연동**
  - `/study-times/total` : 누적 공부 시간 API 구현
  - `/plans/stats` : 전체 플랜 수 + 완료 수 조회 API 구현
  - `/diaries` : 월 지정 없이 호출 시 전체 일기 목록 조회 → 개수 표시 가능
  
<br><br>

## 참고 사항
- `useEffect` 내 다수의 비동기 API 호출을 통해 그래프 및 요약 통계를 한 번에 보여주는 형태.
- 학습 시간은 시간 단위(HH시간 MM분)로 포맷
- 날짜 포맷은 `formatDateWithDayKorean` 함수로 한국어 스타일 적용
<br><br>

## 관련 이슈

- Close #XXX

<br><br>
