### PR TITLE
fix: useCurrentUser 구조분해 누락으로 인한 WebRTC user undefined 문제 수정

### DIFF
--- a/frontend/src/pages/rooms/StudyRoom.js
+++ b/frontend/src/pages/rooms/StudyRoom.js
@@ -14,10 +14,8 @@ import { toast } from "react-toastify";
 
 const StudyRoom = () => {
   const navigate = useNavigate();
-  const user = useCurrentUser();
+  const { user } = useCurrentUser();
   const { roomId } = useParams();
-  const userId = user?.id;
-  const myNickname = user?.nickname || "익명";
   const hasExitedRef = useRef(false);
 
   const [room, setRoom] = useState(null);


### PR DESCRIPTION
## 요약
`useCurrentUser`에서 `user`를 구조분해 하지 않아 WebRTC 로직에서 `user.id`가 undefined로 찍히는 문제가 발생함.

<br><br>

## 작업 내용
- `const user = useCurrentUser()` → `const { user } = useCurrentUser()`로 구조분해 적용
- WebRTC 흐름이 정상적으로 동작하도록 수정
<br><br>

## 참고 사항
- 해당 문제로 인해 `sendSignal`이 실행되지 않던 문제 해결됨

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>
