### PR TITLE
feat: Https(SSL) 적용 및 자동 배포 워크플로우 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: SSH into EC2 and Deploy
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /home/ubuntu
+            docker-compose -f docker-compose.prod.yml down
+            docker-compose -f docker-compose.prod.yml pull
+            docker-compose -f docker-compose.prod.yml up -d

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,10 +25,14 @@ services:
     restart: always
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - backend
     networks:
       - network
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - /etc/letsencrypt/archive:/etc/letsencrypt/archive:ro
 
 networks:
   network:

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -22,8 +22,23 @@ http {
         server backend:8080;
     }
 
+    ## HTTP 접속은 HTTPS로 리다이렉트
     server {
         listen 80;
+        server_name studywithus.kro.kr;
+        return 301 https://$host$request_uri;
+    }
+
+    ## HTTPS 설정
+    server {
+        listen 443 ssl;
+        server_name studywithus.kro.kr;
+
+        ssl_certificate /etc/letsencrypt/live/studywithus.kro.kr/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/studywithus.kro.kr/privkey.pem;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
 
         location / {
             root   /usr/share/nginx/html;


### PR DESCRIPTION
## 요약
프로덕션 환경에서 HTTPS 접속을 지원하도록 설정하고,
GitHub Actions 기반의 EC2 자동 배포 워크플로우를 추가했음.
<br><br>

## 작업 내용
- nginx.conf에 listen 443 ssl 및 인증서 경로 설정 추가
- 도커 컴포즈에서 443 포트 매핑 (`443:443`) 추가
- `/etc/letsencrypt` 및 `/etc/letsencrypt/archive` 디렉토리 볼륨 마운트 추가
  → 컨테이너 내 nginx가 인증서를 참조 가능하게 함
- GitHub Actions 워크플로우 (`deploy.yml`) 작성
  → main 브랜치에 푸시될 경우 EC2에 접속해 컨테이너 재배포 자동화
<br><br>

## 참고 사항
- HTTPS 접속을 위해 Let's Encrypt 기반 인증서 적용
- `.env.prod`, `docker-compose.prod.yml`은 수동 업로드되었으며, 이후 필요 시 별도 처리 가능
- 기존 HTTP 접근 시 HTTPS로 리다이렉트되도록 설정
<br><br>

## 관련 이슈
- Close #XXX

<br><br>
