### PR TITLE
fix: 배포환경 OAuth2 경로 문제 해결

### DIFF
--- a/backend/src/main/java/com/swu/auth/handler/CustomSuccessHandler.java
+++ b/backend/src/main/java/com/swu/auth/handler/CustomSuccessHandler.java
@@ -15,7 +15,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -24,11 +23,17 @@ import lombok.extern.slf4j.Slf4j;
  * - 이후 프론트엔드로 리다이렉트 처리
  */
 @Slf4j
-@RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JWTUtil jwtUtil;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final String frontendBaseUrl;
+
+    public CustomSuccessHandler(JWTUtil jwtUtil, RedisTemplate<String, Object> redisTemplate, String frontendBaseUrl) {
+        this.jwtUtil = jwtUtil;
+        this.redisTemplate = redisTemplate;
+        this.frontendBaseUrl = frontendBaseUrl;
+    }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -52,10 +57,12 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // 5. OAuth2 로그인 후 리다이렉트 처리
         String redirectUrl;
         switch (principal.getUser().getRole()) {
-            case PREUSER -> redirectUrl = "http://localhost:3000/complete-info";
-            case USER -> redirectUrl = "http://localhost:3000/rooms";
-            default -> redirectUrl = "http://localhost:3000/";
+            case PREUSER -> redirectUrl = frontendBaseUrl + "/complete-info";
+            case USER -> redirectUrl = frontendBaseUrl + "/rooms";
+            default -> redirectUrl = frontendBaseUrl;
         }
+
+        log.info("Redirect URL: {}", redirectUrl);
 
         response.sendRedirect(redirectUrl); 
 

--- a/backend/src/main/java/com/swu/config/SecurityConfig.java
+++ b/backend/src/main/java/com/swu/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.swu.auth.service.CustomOAuth2UserService;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -31,6 +32,9 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint; 
     private final RedisTemplate<String, Object> redisTemplate;
     private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Value("${custom.frontend.base-url}")
+    private String frontendBaseUrl;
 
     // 비밀번호 암호화를 위한 Bean 등록
     @Bean
@@ -66,7 +70,7 @@ public class SecurityConfig {
         // OAuth2 로그인 설정
         http
                 .oauth2Login((oauth2) -> oauth2
-                        .successHandler(new CustomSuccessHandler(jwtUtil, redisTemplate))
+                        .successHandler(new CustomSuccessHandler(jwtUtil, redisTemplate, frontendBaseUrl))
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService)));
         

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -63,3 +63,7 @@ cloud:
 logging:
   level:
     root: info
+
+custom:
+  frontend:
+    base-url: ${FRONTEND_BASE_URL}

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -66,6 +66,29 @@ http {
             proxy_set_header X-Forwarded-Host $server_name;
         }
 
+        location /oauth2/ {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Host $server_name;
+        }
+
+        location /login/ {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $server_name;
+        }
 
         location /api/ {
             proxy_pass http://backend;

--- a/frontend/src/components/AuthForm.js
+++ b/frontend/src/components/AuthForm.js
@@ -29,7 +29,7 @@ const AuthForm = () => {
   const [showPassword, setShowPassword] = useState(false);
 
   const handleSocialLogin = (platform) => {
-    const baseUrl = process.env.REACT_APP_SERVER_ORIGIN;
+    const baseUrl = process.env.REACT_APP_SERVER_ORIGIN || "https://studywithus.kro.kr";
 
     window.location.href = `${baseUrl}/oauth2/authorization/${platform.toLowerCase()}`;
   };


### PR DESCRIPTION
## 요약
배포 환경에서 OAuth2이 작동하지 않는 문제를 해결하기 위해,
프론트 도메인을 환경변수로 분리하고 리다이렉트 경로를 외부 도메인 기준으로 변경함.
<br><br>

## 작업 내용
- `AuthForm.jsx`: 서버 주소 fallback을 수정
- `nginx.conf`: `/login/`, `/oauth2/` 경로에 대한 프록시 패스 설정 추가
- `application-prod.yml`: `custom.frontend.base-url` 환경변수 추가
- `SecurityConfig`에서 프론트 주소 주입 구조 개선
- `CustomSuccessHandler`: 프론트 도메인 기준으로 리다이렉트 경로 설정

<br><br>

## 참고 사항
- 개발 환경에서는 기존 방식 유지 (`localhost`로 작동)
- 배포 환경에서만 도메인 적용
<br><br>

## 관련 이슈

- Close #XXX

<br><br>
