### PR TITLE
fix: @Lob 필드의 TinyText 한계 해결을 위한 columnDefinition 지정

### DIFF
--- a/backend/src/main/java/com/swu/domain/diary/entity/Diary.java
+++ b/backend/src/main/java/com/swu/domain/diary/entity/Diary.java
@@ -47,5 +47,6 @@ public class Diary {
     private LocalDateTime createdAt;
 
     @Lob
+    @Column(columnDefinition = "TEXT")
     private String feedback;
 }


### PR DESCRIPTION
## 요약
AI 피드백이 정상적으로 저장되지 않는 이슈가 발견되어,  
`@Lob` 어노테이션의 기본 타입인 `tinytext`를 `TEXT`로 명시적으로 지정함.
<br><br>

## 작업 내용
- `Diary` 엔티티의 `feedback` 필드에 `@Column(columnDefinition = "TEXT")` 추가

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #XXX

<br><br>
